### PR TITLE
Tabs for multiple open documents per window

### DIFF
--- a/README.md
+++ b/README.md
@@ -91,7 +91,7 @@ Annotations use a **text + context** anchoring strategy (inspired by [Hypothes.i
 
 - [ ] **Search** (`⌘F`) — find-in-document with match highlighting
 - [x] **Export annotations** — Markdown or JSON dump of all highlights and notes
-- [ ] **Multiple files** — tabbed or sidebar-based file browser
+- [x] **Multiple files** — file browser sidebar (`⌘⇧F`) and a tab bar for multiple open documents
 - [x] **Mermaid diagrams** — render `mermaid` fenced code blocks inline
 - [x] **Image support** — resolve relative image paths from the `.md` file's directory
 - [x] **PDF export** — `⌘P` exports the document as a paginated Letter-size PDF with print-styled typography

--- a/Sources/mindle/ContentView.swift
+++ b/Sources/mindle/ContentView.swift
@@ -17,16 +17,21 @@ struct ContentView: View {
             if store.fileURL == nil {
                 EmptyStateView()
             } else {
-                HSplitView {
-                    if store.showFileBrowser {
-                        FileBrowserSidebar()
-                            .frame(minWidth: 200, idealWidth: 260, maxWidth: 400)
+                VStack(spacing: 0) {
+                    if store.tabs.count >= 2 {
+                        TabBar()
                     }
-                    ReaderPane()
-                        .frame(minWidth: 480)
-                    if store.showAnnotations {
-                        AnnotationsSidebar()
-                            .frame(minWidth: 280, idealWidth: 340, maxWidth: 460)
+                    HSplitView {
+                        if store.showFileBrowser {
+                            FileBrowserSidebar()
+                                .frame(minWidth: 200, idealWidth: 260, maxWidth: 400)
+                        }
+                        ReaderPane()
+                            .frame(minWidth: 480)
+                        if store.showAnnotations {
+                            AnnotationsSidebar()
+                                .frame(minWidth: 280, idealWidth: 340, maxWidth: 460)
+                        }
                     }
                 }
             }
@@ -607,5 +612,91 @@ struct FileTreeRow: View {
             }
             .buttonStyle(.plain)
         }
+    }
+}
+
+// MARK: - Tab bar
+
+struct TabBar: View {
+    @EnvironmentObject var store: DocumentStore
+
+    var body: some View {
+        let c = store.theme.colors
+        ScrollView(.horizontal, showsIndicators: false) {
+            HStack(spacing: 0) {
+                ForEach(store.tabs) { tab in
+                    TabBarItem(tab: tab)
+                }
+            }
+        }
+        .background(c.surface.opacity(0.5))
+        .overlay(alignment: .bottom) {
+            Rectangle().fill(c.rule.opacity(0.4)).frame(height: 0.5)
+        }
+    }
+}
+
+struct TabBarItem: View {
+    let tab: DocumentTab
+    @EnvironmentObject var store: DocumentStore
+    @State private var isHovering: Bool = false
+
+    var body: some View {
+        let c = store.theme.colors
+        let isActive = store.activeTabID == tab.id
+        let bg: Color = isActive
+            ? c.background
+            : (isHovering ? c.surface.opacity(0.7) : Color.clear)
+
+        ZStack(alignment: .trailing) {
+            // Underlying activate button — fills the row, with a clear
+            // spacer reserving the X button's hit area on the right.
+            Button {
+                store.activate(tabID: tab.id)
+            } label: {
+                HStack(spacing: 6) {
+                    Image(systemName: "doc.text")
+                        .font(.system(size: 10))
+                        .foregroundStyle(isActive ? c.accent : c.muted)
+                    Text(tab.fileURL.lastPathComponent)
+                        .font(.system(size: 12, design: .serif))
+                        .foregroundStyle(isActive ? c.text : c.muted)
+                        .lineLimit(1)
+                        .truncationMode(.middle)
+                    Spacer(minLength: 0)
+                    Color.clear.frame(width: 18, height: 14)
+                }
+                .padding(.horizontal, 10)
+                .padding(.vertical, 7)
+                .frame(minWidth: 120, maxWidth: 220)
+                .background(bg)
+                .contentShape(Rectangle())
+            }
+            .buttonStyle(.plain)
+
+            // Close button — drawn on top of the activate button so its
+            // hit-test wins for clicks inside the X glyph.
+            Button {
+                store.closeTab(id: tab.id)
+            } label: {
+                Image(systemName: "xmark")
+                    .font(.system(size: 9, weight: .semibold))
+                    .foregroundStyle(c.muted)
+                    .frame(width: 16, height: 16)
+                    .background(
+                        Circle()
+                            .fill(isHovering ? c.muted.opacity(0.18) : Color.clear)
+                    )
+                    .contentShape(Rectangle())
+            }
+            .buttonStyle(.plain)
+            .opacity(isActive || isHovering ? 1 : 0.6)
+            .padding(.trailing, 8)
+            .help("Close tab")
+        }
+        .overlay(alignment: .trailing) {
+            Rectangle().fill(c.rule.opacity(0.3)).frame(width: 0.5)
+        }
+        .onHover { isHovering = $0 }
     }
 }

--- a/Sources/mindle/ContentView.swift
+++ b/Sources/mindle/ContentView.swift
@@ -648,52 +648,48 @@ struct TabBarItem: View {
             ? c.background
             : (isHovering ? c.surface.opacity(0.7) : Color.clear)
 
-        ZStack(alignment: .trailing) {
-            // Underlying activate button — fills the row, with a clear
-            // spacer reserving the X button's hit area on the right.
-            Button {
+        // Two side-by-side hit regions wired via onTapGesture, instead of
+        // stacked Buttons — macOS SwiftUI's Button hit-test in a ZStack
+        // can extend beyond the visible label and swallow clicks across
+        // the whole row. Plain tap gestures on sibling views stay scoped.
+        HStack(spacing: 0) {
+            HStack(spacing: 6) {
+                Image(systemName: "doc.text")
+                    .font(.system(size: 10))
+                    .foregroundStyle(isActive ? c.accent : c.muted)
+                Text(tab.fileURL.lastPathComponent)
+                    .font(.system(size: 12, design: .serif))
+                    .foregroundStyle(isActive ? c.text : c.muted)
+                    .lineLimit(1)
+                    .truncationMode(.middle)
+                Spacer(minLength: 0)
+            }
+            .padding(.leading, 10)
+            .padding(.vertical, 7)
+            .frame(minWidth: 100, maxWidth: 200, alignment: .leading)
+            .contentShape(Rectangle())
+            .onTapGesture {
                 store.activate(tabID: tab.id)
-            } label: {
-                HStack(spacing: 6) {
-                    Image(systemName: "doc.text")
-                        .font(.system(size: 10))
-                        .foregroundStyle(isActive ? c.accent : c.muted)
-                    Text(tab.fileURL.lastPathComponent)
-                        .font(.system(size: 12, design: .serif))
-                        .foregroundStyle(isActive ? c.text : c.muted)
-                        .lineLimit(1)
-                        .truncationMode(.middle)
-                    Spacer(minLength: 0)
-                    Color.clear.frame(width: 18, height: 14)
-                }
-                .padding(.horizontal, 10)
-                .padding(.vertical, 7)
-                .frame(minWidth: 120, maxWidth: 220)
-                .background(bg)
-                .contentShape(Rectangle())
             }
-            .buttonStyle(.plain)
 
-            // Close button — drawn on top of the activate button so its
-            // hit-test wins for clicks inside the X glyph.
-            Button {
-                store.closeTab(id: tab.id)
-            } label: {
-                Image(systemName: "xmark")
-                    .font(.system(size: 9, weight: .semibold))
-                    .foregroundStyle(c.muted)
-                    .frame(width: 16, height: 16)
-                    .background(
-                        Circle()
-                            .fill(isHovering ? c.muted.opacity(0.18) : Color.clear)
-                    )
-                    .contentShape(Rectangle())
-            }
-            .buttonStyle(.plain)
-            .opacity(isActive || isHovering ? 1 : 0.6)
-            .padding(.trailing, 8)
-            .help("Close tab")
+            Image(systemName: "xmark")
+                .font(.system(size: 9, weight: .semibold))
+                .foregroundStyle(c.muted)
+                .frame(width: 16, height: 16)
+                .background(
+                    Circle()
+                        .fill(isHovering ? c.muted.opacity(0.18) : Color.clear)
+                )
+                .padding(.horizontal, 6)
+                .padding(.vertical, 7)
+                .contentShape(Rectangle())
+                .opacity(isActive || isHovering ? 1 : 0.6)
+                .onTapGesture {
+                    store.closeTab(id: tab.id)
+                }
+                .help("Close tab")
         }
+        .background(bg)
         .overlay(alignment: .trailing) {
             Rectangle().fill(c.rule.opacity(0.3)).frame(width: 0.5)
         }

--- a/Sources/mindle/ContentView.swift
+++ b/Sources/mindle/ContentView.swift
@@ -6,12 +6,11 @@ struct ContentView: View {
 
     var body: some View {
         let c = store.theme.colors
-        // The themed fill needs to extend through the toolbar safe
-        // area so the unified-toolbar's translucent material picks up
-        // the theme color as its backdrop. Without .ignoresSafeArea()
-        // the material bleeds to the window's system-gray backing and
-        // the toolbar reads as a flat dark bar.
         ZStack {
+            // The themed fill needs to extend through the toolbar safe
+            // area so the unified-toolbar's translucent material picks up
+            // the theme color as its backdrop. Without .ignoresSafeArea()
+            // the material bleeds to the window's system-gray backing.
             c.background.ignoresSafeArea()
 
             if store.fileURL == nil {
@@ -622,12 +621,14 @@ struct TabBar: View {
 
     var body: some View {
         let c = store.theme.colors
-        ScrollView(.horizontal, showsIndicators: false) {
-            HStack(spacing: 0) {
-                ForEach(store.tabs) { tab in
-                    TabBarItem(tab: tab)
-                }
+        // Plain HStack rather than ScrollView: NSScrollView eats the first
+        // mouse-down to disambiguate scroll-vs-tap, which blocked the inner
+        // Buttons from firing. Many-tabs overflow can be revisited later.
+        HStack(spacing: 0) {
+            ForEach(store.tabs) { tab in
+                TabBarItem(tab: tab)
             }
+            Spacer(minLength: 0)
         }
         .background(c.surface.opacity(0.5))
         .overlay(alignment: .bottom) {
@@ -648,46 +649,50 @@ struct TabBarItem: View {
             ? c.background
             : (isHovering ? c.surface.opacity(0.7) : Color.clear)
 
-        // Two side-by-side hit regions wired via onTapGesture, instead of
-        // stacked Buttons — macOS SwiftUI's Button hit-test in a ZStack
-        // can extend beyond the visible label and swallow clicks across
-        // the whole row. Plain tap gestures on sibling views stay scoped.
+        // Two real Buttons side-by-side in an HStack. Button's underlying
+        // NSView opts out of window-drag (mouseDownCanMoveWindow = false),
+        // which onTapGesture does not — so this layout works even if the
+        // tab bar overlaps a window-drag region.
         HStack(spacing: 0) {
-            HStack(spacing: 6) {
-                Image(systemName: "doc.text")
-                    .font(.system(size: 10))
-                    .foregroundStyle(isActive ? c.accent : c.muted)
-                Text(tab.fileURL.lastPathComponent)
-                    .font(.system(size: 12, design: .serif))
-                    .foregroundStyle(isActive ? c.text : c.muted)
-                    .lineLimit(1)
-                    .truncationMode(.middle)
-                Spacer(minLength: 0)
-            }
-            .padding(.leading, 10)
-            .padding(.vertical, 7)
-            .frame(minWidth: 100, maxWidth: 200, alignment: .leading)
-            .contentShape(Rectangle())
-            .onTapGesture {
+            Button {
                 store.activate(tabID: tab.id)
-            }
-
-            Image(systemName: "xmark")
-                .font(.system(size: 9, weight: .semibold))
-                .foregroundStyle(c.muted)
-                .frame(width: 16, height: 16)
-                .background(
-                    Circle()
-                        .fill(isHovering ? c.muted.opacity(0.18) : Color.clear)
-                )
-                .padding(.horizontal, 6)
-                .padding(.vertical, 7)
-                .contentShape(Rectangle())
-                .opacity(isActive || isHovering ? 1 : 0.6)
-                .onTapGesture {
-                    store.closeTab(id: tab.id)
+            } label: {
+                HStack(spacing: 6) {
+                    Image(systemName: "doc.text")
+                        .font(.system(size: 10))
+                        .foregroundStyle(isActive ? c.accent : c.muted)
+                    Text(tab.fileURL.lastPathComponent)
+                        .font(.system(size: 12, design: .serif))
+                        .foregroundStyle(isActive ? c.text : c.muted)
+                        .lineLimit(1)
+                        .truncationMode(.middle)
+                    Spacer(minLength: 0)
                 }
-                .help("Close tab")
+                .padding(.leading, 10)
+                .padding(.vertical, 7)
+                .frame(minWidth: 100, maxWidth: 200, alignment: .leading)
+                .contentShape(Rectangle())
+            }
+            .buttonStyle(.plain)
+
+            Button {
+                store.closeTab(id: tab.id)
+            } label: {
+                Image(systemName: "xmark")
+                    .font(.system(size: 9, weight: .semibold))
+                    .foregroundStyle(c.muted)
+                    .frame(width: 16, height: 16)
+                    .background(
+                        Circle()
+                            .fill(isHovering ? c.muted.opacity(0.18) : Color.clear)
+                    )
+                    .padding(.horizontal, 6)
+                    .padding(.vertical, 7)
+                    .contentShape(Rectangle())
+            }
+            .buttonStyle(.plain)
+            .opacity(isActive || isHovering ? 1 : 0.6)
+            .help("Close tab")
         }
         .background(bg)
         .overlay(alignment: .trailing) {

--- a/Sources/mindle/DocumentStore.swift
+++ b/Sources/mindle/DocumentStore.swift
@@ -24,6 +24,17 @@ struct FileNode: Identifiable, Equatable {
     let children: [FileNode]?   // nil = leaf file; non-nil = directory
 }
 
+/// One open document inside a window. Active-tab state still lives in
+/// the window-scoped @Published vars (`fileURL`, `rawText`, `annotations`)
+/// so all existing features keep working untouched; inactive tabs are
+/// snapshotted here and rehydrated on activate.
+struct DocumentTab: Identifiable, Equatable {
+    let id: UUID
+    var fileURL: URL
+    var rawText: String
+    var annotations: [Annotation]
+}
+
 @MainActor
 final class DocumentStore: ObservableObject {
     @Published var fileURL: URL?
@@ -35,6 +46,11 @@ final class DocumentStore: ObservableObject {
     @Published var showAnnotations: Bool = false
     @Published var showFileBrowser: Bool = false
     @Published var fileTree: FileNode? = nil
+
+    // Tabs (per-window). Empty when no document is open; otherwise the active
+    // tab's state mirrors `fileURL` / `rawText` / `annotations` above.
+    @Published var tabs: [DocumentTab] = []
+    @Published var activeTabID: UUID? = nil
 
     // Search
     @Published var showSearch: Bool = false
@@ -80,6 +96,12 @@ final class DocumentStore: ObservableObject {
     }
 
     func open(url: URL) {
+        // Already open in this window? Switch to its tab without re-reading from disk.
+        if let existing = tabs.first(where: { $0.fileURL == url }) {
+            activate(tabID: existing.id)
+            return
+        }
+
         do {
             let text = try String(contentsOf: url, encoding: .utf8)
             // Re-root the file tree only when the new file is outside the current scope.
@@ -91,11 +113,28 @@ final class DocumentStore: ObservableObject {
                 shouldRebuildTree = true
             }
 
+            // Persist the outgoing tab's in-memory state into its snapshot so
+            // we can rehydrate it without going back to disk if the user
+            // returns to it.
+            snapshotActiveTab()
+
+            let newTab = DocumentTab(id: UUID(), fileURL: url, rawText: text, annotations: [])
+            tabs.append(newTab)
+            activeTabID = newTab.id
+
             closeSearch()
+            focusedAnnotation = nil
+            editingAnnotationID = nil
+            updateSelection(text: "", prefix: "", suffix: "")
+
             self.fileURL = url
             self.rawText = text
             self.annotations = []
             self.loadSidecar()
+
+            // Capture the sidecar-loaded annotations into the tab snapshot.
+            snapshotActiveTab()
+
             if shouldRebuildTree {
                 refreshFileTree()
             }
@@ -103,6 +142,69 @@ final class DocumentStore: ObservableObject {
         } catch {
             NSSound.beep()
         }
+    }
+
+    // MARK: - Tabs
+
+    func activate(tabID: UUID) {
+        guard activeTabID != tabID,
+              let target = tabs.first(where: { $0.id == tabID }) else { return }
+        snapshotActiveTab()
+        activeTabID = tabID
+        loadTabState(target)
+    }
+
+    func closeTab(id: UUID) {
+        guard let i = tabs.firstIndex(where: { $0.id == id }) else { return }
+        let isActive = (activeTabID == id)
+
+        // Make sure the snapshot we save reflects the latest in-memory state.
+        if isActive {
+            snapshotActiveTab()
+        }
+        saveSidecar(forTab: tabs[i])
+
+        tabs.remove(at: i)
+
+        guard isActive else { return }
+
+        if i < tabs.count {
+            let target = tabs[i]
+            activeTabID = target.id
+            loadTabState(target)
+        } else if let last = tabs.last {
+            activeTabID = last.id
+            loadTabState(last)
+        } else {
+            // Last tab closed — back to empty state.
+            activeTabID = nil
+            fileURL = nil
+            rawText = ""
+            annotations = []
+            closeSearch()
+            focusedAnnotation = nil
+            editingAnnotationID = nil
+            updateSelection(text: "", prefix: "", suffix: "")
+        }
+    }
+
+    private func snapshotActiveTab() {
+        guard let id = activeTabID,
+              let i = tabs.firstIndex(where: { $0.id == id }),
+              let url = fileURL else { return }
+        tabs[i].fileURL = url
+        tabs[i].rawText = rawText
+        tabs[i].annotations = annotations
+    }
+
+    private func loadTabState(_ tab: DocumentTab) {
+        fileURL = tab.fileURL
+        rawText = tab.rawText
+        annotations = tab.annotations
+        closeSearch()
+        focusedAnnotation = nil
+        editingAnnotationID = nil
+        updateSelection(text: "", prefix: "", suffix: "")
     }
 
     // MARK: - File browser
@@ -289,6 +391,16 @@ final class DocumentStore: ObservableObject {
 
     func saveSidecar() {
         guard let url = sidecarURL else { return }
+        writeSidecar(to: url, annotations: annotations)
+    }
+
+    private func saveSidecar(forTab tab: DocumentTab) {
+        let url = tab.fileURL.deletingLastPathComponent()
+            .appendingPathComponent(".\(tab.fileURL.lastPathComponent).mindle.json")
+        writeSidecar(to: url, annotations: tab.annotations)
+    }
+
+    private func writeSidecar(to url: URL, annotations: [Annotation]) {
         let encoder = JSONEncoder()
         encoder.outputFormatting = [.prettyPrinted, .sortedKeys]
         encoder.dateEncodingStrategy = .iso8601

--- a/Sources/mindle/MindleApp.swift
+++ b/Sources/mindle/MindleApp.swift
@@ -119,6 +119,21 @@ struct MindleCommands: Commands {
                 .disabled(!(store?.canExportAnnotations ?? false))
         }
 
+        // Replace the default Close so ⌘W closes the active tab when more
+        // than one is open in the focused window. Falls back to closing the
+        // window itself for single-tab (or empty) windows — the standard
+        // Safari/Xcode pattern.
+        CommandGroup(replacing: .saveItem) {
+            Button((store?.tabs.count ?? 0) >= 2 ? "Close Tab" : "Close") {
+                if let store, store.tabs.count >= 2, let id = store.activeTabID {
+                    store.closeTab(id: id)
+                } else {
+                    NSApp.keyWindow?.performClose(nil)
+                }
+            }
+            .keyboardShortcut("w", modifiers: .command)
+        }
+
         CommandGroup(replacing: .printItem) {
             Button("Export as PDF…") { store?.requestPDFExport() }
                 .keyboardShortcut("p", modifiers: .command)


### PR DESCRIPTION
## Summary
- Each window's `DocumentStore` now owns a `tabs[]` / `activeTabID` pair. The active tab's state still lives in the existing `fileURL` / `rawText` / `annotations` @Published vars, so search, file browser, PDF export, sidecar persistence, and the annotations sidebar keep working untouched. Inactive tabs are snapshotted as `DocumentTab` and rehydrated on activate without re-reading from disk.
- `open(url:)` appends a new tab (or switches to an existing one when the URL is already open in this window) instead of replacing the document.
- The tab bar is hidden when only one tab is open, so single-document UX is unchanged.
- `⌘W` now closes the active tab when 2+ tabs are open in the focused window, falling back to the standard window close otherwise (Safari/Xcode pattern).

Closes #3.

## Test plan
- [ ] Open one document — no tab bar shown.
- [ ] Open a second document via `⌘O` — tab bar appears, both files reachable.
- [ ] Open a third via the file browser sidebar — appended as a new tab.
- [ ] Click between tabs — annotations sidebar, search, theme/font, and the rendered HTML all switch correctly.
- [ ] Add a highlight on tab A, switch to B, switch back — highlight persists in memory.
- [ ] Close a tab via the X button — sidecar saved; neighbouring tab takes focus.
- [ ] `⌘W` with 2+ tabs closes the active tab; `⌘W` with one tab closes the window.
- [ ] Open the same file twice in one window — second `⌘O` switches to the existing tab, doesn't duplicate.
- [ ] Multi-window still works (each window has its own independent set of tabs).