### PR TITLE
v2.0 Phase 1: MCP server skeleton (list_open_files)

### DIFF
--- a/Sources/MindleMCP/main.swift
+++ b/Sources/MindleMCP/main.swift
@@ -1,0 +1,269 @@
+import Foundation
+import Darwin
+
+// `mindle-mcp`: stdio MCP helper. Reads newline-delimited JSON-RPC from
+// stdin, translates each tools/call into a length-prefixed JSON request
+// over the running Mindle's Unix socket, and emits the JSON-RPC response
+// on stdout.
+//
+// Read-only by design: Mindle exposes only what no other tool can —
+// open-files state and the annotation feedback channel. Filesystem reads
+// belong in the agent's normal Read tool, not here.
+
+@main
+struct MindleMCP {
+
+    static func main() {
+        // Synchronous read loop — async/Task on stdin proved flaky in
+        // this CLI context. POSIX read on fd 0 is bulletproof.
+        var buffer = Data()
+        var chunk = [UInt8](repeating: 0, count: 4096)
+        while true {
+            let n = chunk.withUnsafeMutableBufferPointer { ptr -> Int in
+                read(0, ptr.baseAddress, ptr.count)
+            }
+            if n <= 0 { break }   // EOF or error
+            buffer.append(contentsOf: chunk[0..<n])
+            while let nlOffset = buffer.firstIndex(of: 0x0A) {
+                let line = buffer.prefix(upTo: nlOffset)
+                buffer.removeSubrange(buffer.startIndex...nlOffset)
+                guard !line.isEmpty else { continue }
+                if let response = handle(line: Data(line)) {
+                    emit(response: response)
+                }
+            }
+        }
+    }
+
+    /// Renamed from `write(response:)` to avoid shadowing Darwin's
+    /// `write(_:_:_)` syscall used by the socket bridge below.
+    private static func emit(response: [String: Any]) {
+        guard let data = try? JSONSerialization.data(withJSONObject: response) else { return }
+        FileHandle.standardOutput.write(data)
+        FileHandle.standardOutput.write(Data([0x0A]))
+    }
+
+    // MARK: - JSON-RPC dispatch
+
+    private static func handle(line: Data) -> [String: Any]? {
+        guard let req = try? JSONSerialization.jsonObject(with: line) as? [String: Any],
+              let method = req["method"] as? String else {
+            return nil
+        }
+        let id = req["id"]
+        let params = (req["params"] as? [String: Any]) ?? [:]
+
+        // Notifications carry no `id` and don't expect a response.
+        if id == nil {
+            // We accept and ignore notifications/initialized, etc.
+            return nil
+        }
+
+        switch method {
+        case "initialize":
+            return success(id: id!, result: [
+                "protocolVersion": "2024-11-05",
+                "capabilities": ["tools": [String: Any]()],
+                "serverInfo": [
+                    "name": "mindle",
+                    "version": "0.1.0"
+                ]
+            ])
+
+        case "tools/list":
+            return success(id: id!, result: ["tools": toolDefinitions()])
+
+        case "tools/call":
+            let result = handleToolCall(params: params)
+            return success(id: id!, result: result)
+
+        default:
+            return error(id: id!, code: -32601, message: "Method not found: \(method)")
+        }
+    }
+
+    private static func success(id: Any, result: [String: Any]) -> [String: Any] {
+        return [
+            "jsonrpc": "2.0",
+            "id": id,
+            "result": result
+        ]
+    }
+
+    private static func error(id: Any, code: Int, message: String) -> [String: Any] {
+        return [
+            "jsonrpc": "2.0",
+            "id": id,
+            "error": ["code": code, "message": message]
+        ]
+    }
+
+    // MARK: - Tool surface (Phase 1: list_open_files only)
+
+    private static func toolDefinitions() -> [[String: Any]] {
+        return [
+            [
+                "name": "list_open_files",
+                "description": "List the absolute paths of every Markdown file currently open in Mindle (across all windows and tabs). Use this to see what the user is reading right now.",
+                "inputSchema": [
+                    "type": "object",
+                    "properties": [String: Any](),
+                    "additionalProperties": false
+                ]
+            ]
+        ]
+    }
+
+    private static func handleToolCall(params: [String: Any]) -> [String: Any] {
+        guard let name = params["name"] as? String else {
+            return errorContent("missing tool name")
+        }
+        switch name {
+        case "list_open_files":
+            return callMindle(op: "list_open_files", body: [:]) { resp in
+                guard let files = resp["files"] as? [String] else {
+                    return errorContent("malformed response from Mindle")
+                }
+                if files.isEmpty {
+                    return textContent("No files are currently open in Mindle.")
+                }
+                let listing = files.map { "- \($0)" }.joined(separator: "\n")
+                return textContent("Files currently open in Mindle:\n\n\(listing)")
+            }
+        default:
+            return errorContent("unknown tool: \(name)")
+        }
+    }
+
+    private static func textContent(_ text: String) -> [String: Any] {
+        return [
+            "content": [["type": "text", "text": text]]
+        ]
+    }
+
+    private static func errorContent(_ text: String) -> [String: Any] {
+        return [
+            "content": [["type": "text", "text": text]],
+            "isError": true
+        ]
+    }
+
+    // MARK: - Socket bridge to running Mindle
+
+    /// Connect to ~/Library/Caches/local.fnp.mindle/mcp.sock, send a
+    /// length-prefixed JSON request, parse the length-prefixed response,
+    /// and pass it to `format`. Surface a clear error if Mindle isn't
+    /// running rather than crashing or hanging.
+    private static func callMindle(
+        op: String,
+        body: [String: Any],
+        format: ([String: Any]) -> [String: Any]
+    ) -> [String: Any] {
+        let cache = FileManager.default
+            .urls(for: .cachesDirectory, in: .userDomainMask).first
+        guard let path = cache?
+            .appendingPathComponent("local.fnp.mindle", isDirectory: true)
+            .appendingPathComponent("mcp.sock").path else {
+            return errorContent("Could not resolve Mindle's socket path.")
+        }
+
+        let fd = Darwin.socket(AF_UNIX, SOCK_STREAM, 0)
+        guard fd >= 0 else {
+            return errorContent("socket() failed: \(String(cString: strerror(errno)))")
+        }
+        defer { close(fd) }
+
+        var addr = sockaddr_un()
+        addr.sun_family = sa_family_t(AF_UNIX)
+        let pathBytes = Array(path.utf8) + [0]
+        let cap = MemoryLayout.size(ofValue: addr.sun_path)
+        guard pathBytes.count <= cap else {
+            return errorContent("Mindle socket path too long")
+        }
+        withUnsafeMutableBytes(of: &addr.sun_path) { dst in
+            pathBytes.withUnsafeBufferPointer { src in
+                _ = memcpy(dst.baseAddress, src.baseAddress, src.count)
+            }
+        }
+
+        let sockLen = socklen_t(MemoryLayout<sockaddr_un>.size)
+        let connectResult = withUnsafePointer(to: &addr) { ptr -> Int32 in
+            ptr.withMemoryRebound(to: sockaddr.self, capacity: 1) { sockPtr in
+                Darwin.connect(fd, sockPtr, sockLen)
+            }
+        }
+        guard connectResult == 0 else {
+            return errorContent("Mindle isn't running. Open Mindle and try again.")
+        }
+
+        var request = body
+        request["op"] = op
+        guard let data = try? JSONSerialization.data(withJSONObject: request) else {
+            return errorContent("could not encode request")
+        }
+        let bytes = [UInt8](data)
+        let len = UInt32(bytes.count)
+        let header: [UInt8] = [
+            UInt8((len >> 24) & 0xff),
+            UInt8((len >> 16) & 0xff),
+            UInt8((len >>  8) & 0xff),
+            UInt8( len        & 0xff)
+        ]
+        guard writeAll(fd: fd, bytes: header), writeAll(fd: fd, bytes: bytes) else {
+            return errorContent("write to Mindle failed")
+        }
+
+        var lenBuf = [UInt8](repeating: 0, count: 4)
+        guard readExact(fd: fd, into: &lenBuf, count: 4) else {
+            return errorContent("Mindle closed the connection")
+        }
+        let payloadLen =
+            (UInt32(lenBuf[0]) << 24) |
+            (UInt32(lenBuf[1]) << 16) |
+            (UInt32(lenBuf[2]) <<  8) |
+             UInt32(lenBuf[3])
+        guard payloadLen > 0, payloadLen < 1_000_000 else {
+            return errorContent("Mindle sent a malformed response length")
+        }
+        var payload = [UInt8](repeating: 0, count: Int(payloadLen))
+        guard readExact(fd: fd, into: &payload, count: Int(payloadLen)) else {
+            return errorContent("Mindle response truncated")
+        }
+
+        guard let resp = try? JSONSerialization.jsonObject(with: Data(payload)) as? [String: Any] else {
+            return errorContent("Mindle sent malformed JSON")
+        }
+        if let ok = resp["ok"] as? Bool, !ok {
+            let msg = (resp["error"] as? String) ?? "unknown error"
+            return errorContent("Mindle: \(msg)")
+        }
+        return format(resp)
+    }
+
+    // MARK: - Wire helpers
+
+    private static func readExact(fd: Int32, into buf: inout [UInt8], count: Int) -> Bool {
+        var got = 0
+        while got < count {
+            let n = buf.withUnsafeMutableBufferPointer { ptr -> Int in
+                read(fd, ptr.baseAddress!.advanced(by: got), count - got)
+            }
+            if n <= 0 { return false }
+            got += n
+        }
+        return true
+    }
+
+    @discardableResult
+    private static func writeAll(fd: Int32, bytes: [UInt8]) -> Bool {
+        var sent = 0
+        return bytes.withUnsafeBufferPointer { ptr -> Bool in
+            while sent < bytes.count {
+                let n = write(fd, ptr.baseAddress!.advanced(by: sent), bytes.count - sent)
+                if n <= 0 { return false }
+                sent += n
+            }
+            return true
+        }
+    }
+}

--- a/Sources/mindle/MCPServer.swift
+++ b/Sources/mindle/MCPServer.swift
@@ -1,0 +1,212 @@
+import Foundation
+import Darwin
+
+/// Unix-socket server that lets the bundled `mindle-mcp` helper proxy
+/// MCP tool calls into the running Mindle app.
+///
+/// The wire protocol on the socket is *not* MCP — it's a tiny internal
+/// JSON dialect (length-prefixed, request/response). The helper does
+/// the MCP framing on stdio; this server just answers questions about
+/// what's open and what the user has annotated. Read-only by design:
+/// the agent has its own filesystem tools for writes.
+///
+/// ```
+/// 4-byte big-endian length || UTF-8 JSON body
+/// request:  {"op": "list_open_files"}
+/// response: {"ok": true, "files": ["/abs/path.md", ...]}
+/// ```
+final class MCPServer {
+
+    static let shared = MCPServer()
+
+    private var listenFD: Int32 = -1
+    private(set) var socketPath: String = ""
+
+    private init() {}
+
+    // MARK: - Public lifecycle
+
+    /// Bind, listen, and start the accept loop on a background task.
+    /// Idempotent — calling twice is a no-op after the first success.
+    func start() {
+        guard listenFD < 0 else { return }
+
+        // ~/Library/Caches/local.fnp.mindle/mcp.sock — under the
+        // 104-byte sun_path limit on macOS for any normal username.
+        let fm = FileManager.default
+        guard let cache = fm.urls(for: .cachesDirectory, in: .userDomainMask).first else {
+            return
+        }
+        let dir = cache.appendingPathComponent("local.fnp.mindle", isDirectory: true)
+        try? fm.createDirectory(at: dir, withIntermediateDirectories: true)
+        let path = dir.appendingPathComponent("mcp.sock").path
+        socketPath = path
+
+        // Stale socket from a previous launch — bind() would fail otherwise.
+        unlink(path)
+
+        let fd = Darwin.socket(AF_UNIX, SOCK_STREAM, 0)
+        guard fd >= 0 else {
+            NSLog("[mindle.mcp] socket() errno=%d", errno)
+            return
+        }
+
+        var addr = sockaddr_un()
+        addr.sun_family = sa_family_t(AF_UNIX)
+        let pathBytes = Array(path.utf8) + [0]
+        let cap = MemoryLayout.size(ofValue: addr.sun_path)
+        guard pathBytes.count <= cap else {
+            close(fd)
+            NSLog("[mindle.mcp] socket path too long (%d > %d)", pathBytes.count, cap)
+            return
+        }
+        withUnsafeMutableBytes(of: &addr.sun_path) { dst in
+            pathBytes.withUnsafeBufferPointer { src in
+                _ = memcpy(dst.baseAddress, src.baseAddress, src.count)
+            }
+        }
+
+        let len = socklen_t(MemoryLayout<sockaddr_un>.size)
+        let bindResult = withUnsafePointer(to: &addr) { ptr -> Int32 in
+            ptr.withMemoryRebound(to: sockaddr.self, capacity: 1) { sockPtr in
+                Darwin.bind(fd, sockPtr, len)
+            }
+        }
+        guard bindResult == 0 else {
+            NSLog("[mindle.mcp] bind() errno=%d", errno)
+            close(fd)
+            return
+        }
+
+        // 0700 — only the user can connect.
+        chmod(path, 0o700)
+
+        guard Darwin.listen(fd, 8) == 0 else {
+            NSLog("[mindle.mcp] listen() errno=%d", errno)
+            close(fd)
+            unlink(path)
+            return
+        }
+
+        listenFD = fd
+
+        Task.detached(priority: .utility) { [path] in
+            await Self.acceptLoop(listenFD: fd, socketPath: path)
+        }
+    }
+
+    /// Called from applicationWillTerminate. Unlinks the socket so the
+    /// next launch starts clean even if accept() has stale state.
+    func stop() {
+        if listenFD >= 0 {
+            close(listenFD)
+            listenFD = -1
+        }
+        if !socketPath.isEmpty {
+            unlink(socketPath)
+        }
+    }
+
+    // MARK: - Accept loop (background)
+
+    private static func acceptLoop(listenFD: Int32, socketPath: String) async {
+        while true {
+            var clientAddr = sockaddr_un()
+            var clientLen = socklen_t(MemoryLayout<sockaddr_un>.size)
+            let clientFD = withUnsafeMutablePointer(to: &clientAddr) { ptr -> Int32 in
+                ptr.withMemoryRebound(to: sockaddr.self, capacity: 1) { p in
+                    Darwin.accept(listenFD, p, &clientLen)
+                }
+            }
+            if clientFD < 0 {
+                if errno == EINTR { continue }
+                // listen socket closed — exit the loop.
+                return
+            }
+            Task.detached(priority: .utility) {
+                await Self.handleClient(fd: clientFD)
+            }
+        }
+    }
+
+    private static func handleClient(fd: Int32) async {
+        defer { close(fd) }
+        guard let req = readMessage(fd: fd) else {
+            sendResponse(fd: fd, response: ["ok": false, "error": "bad request"])
+            return
+        }
+        guard let op = req["op"] as? String else {
+            sendResponse(fd: fd, response: ["ok": false, "error": "missing 'op'"])
+            return
+        }
+        let response = await dispatch(op: op, request: req)
+        sendResponse(fd: fd, response: response)
+    }
+
+    // MARK: - Op dispatch (hops to MainActor for app state)
+
+    private static func dispatch(op: String, request: [String: Any]) async -> [String: Any] {
+        switch op {
+        case "list_open_files":
+            let files = await MainActor.run { AppDelegate.shared?.allOpenFilePaths() ?? [] }
+            return ["ok": true, "files": files]
+        default:
+            return ["ok": false, "error": "unknown op: \(op)"]
+        }
+    }
+
+    // MARK: - Wire helpers (length-prefixed JSON)
+
+    private static func readMessage(fd: Int32) -> [String: Any]? {
+        var lenBytes = [UInt8](repeating: 0, count: 4)
+        guard readExact(fd: fd, into: &lenBytes, count: 4) else { return nil }
+        let payloadLen =
+            (UInt32(lenBytes[0]) << 24) |
+            (UInt32(lenBytes[1]) << 16) |
+            (UInt32(lenBytes[2]) <<  8) |
+             UInt32(lenBytes[3])
+        guard payloadLen > 0, payloadLen < 1_000_000 else { return nil }
+        var payload = [UInt8](repeating: 0, count: Int(payloadLen))
+        guard readExact(fd: fd, into: &payload, count: Int(payloadLen)) else { return nil }
+        return try? JSONSerialization.jsonObject(with: Data(payload)) as? [String: Any]
+    }
+
+    private static func sendResponse(fd: Int32, response: [String: Any]) {
+        guard let data = try? JSONSerialization.data(withJSONObject: response) else { return }
+        let bytes = [UInt8](data)
+        let len = UInt32(bytes.count)
+        let header: [UInt8] = [
+            UInt8((len >> 24) & 0xff),
+            UInt8((len >> 16) & 0xff),
+            UInt8((len >>  8) & 0xff),
+            UInt8( len        & 0xff)
+        ]
+        _ = writeAll(fd: fd, bytes: header)
+        _ = writeAll(fd: fd, bytes: bytes)
+    }
+
+    private static func readExact(fd: Int32, into buf: inout [UInt8], count: Int) -> Bool {
+        var got = 0
+        while got < count {
+            let n = buf.withUnsafeMutableBufferPointer { ptr -> Int in
+                read(fd, ptr.baseAddress!.advanced(by: got), count - got)
+            }
+            if n <= 0 { return false }
+            got += n
+        }
+        return true
+    }
+
+    @discardableResult
+    private static func writeAll(fd: Int32, bytes: [UInt8]) -> Bool {
+        var sent = 0
+        return bytes.withUnsafeBufferPointer { ptr -> Bool in
+            while sent < bytes.count {
+                let n = write(fd, ptr.baseAddress!.advanced(by: sent), bytes.count - sent)
+                if n <= 0 { return false }
+                sent += n
+            }
+            return true
+        }
+    }
+}

--- a/Sources/mindle/MindleApp.swift
+++ b/Sources/mindle/MindleApp.swift
@@ -9,6 +9,12 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
     private var pendingURLs: [URL] = []
     private weak var activeStore: DocumentStore?
 
+    // Weak refs to every DocumentStore that's been registered (one per
+    // open window). Used by the MCP server to aggregate `list_open_files`
+    // across all windows. Cleaned up lazily on register/lookup.
+    private struct WeakStoreRef { weak var store: DocumentStore? }
+    private var registeredStores: [WeakStoreRef] = []
+
     // Sparkle updater: instantiated once per app lifecycle. startingUpdater
     // true lets Sparkle schedule its own background check if the user has
     // opted into automatic updates. On first launch after a version that
@@ -26,6 +32,33 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
         AppDelegate.shared = self
     }
 
+    func applicationDidFinishLaunching(_ notification: Notification) {
+        // MCP server lives for the app lifetime — opens its socket on
+        // launch and tears it down on terminate. The bundled mindle-mcp
+        // helper proxies stdio MCP into this socket.
+        MCPServer.shared.start()
+    }
+
+    func applicationWillTerminate(_ notification: Notification) {
+        MCPServer.shared.stop()
+    }
+
+    /// Aggregated set of file paths currently open across every window's
+    /// tabs. Called from the MCP server on the main actor.
+    func allOpenFilePaths() -> [String] {
+        registeredStores.removeAll { $0.store == nil }
+        var seen: Set<String> = []
+        var ordered: [String] = []
+        for ref in registeredStores {
+            guard let store = ref.store else { continue }
+            for tab in store.tabs {
+                let p = tab.fileURL.path
+                if seen.insert(p).inserted { ordered.append(p) }
+            }
+        }
+        return ordered
+    }
+
     func application(_ sender: NSApplication, open urls: [URL]) {
         if let store = activeStore {
             for url in urls {
@@ -41,8 +74,14 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
 
     /// Each window's RootView calls this on appear, so the most recently
     /// active window becomes the target for externally opened URLs.
+    /// Also tracks the store in `registeredStores` (weak) so the MCP
+    /// server can aggregate open files across every window.
     func register(store: DocumentStore) {
         activeStore = store
+        registeredStores.removeAll { $0.store == nil }
+        if !registeredStores.contains(where: { $0.store === store }) {
+            registeredStores.append(WeakStoreRef(store: store))
+        }
         if !pendingURLs.isEmpty {
             let queued = pendingURLs
             pendingURLs.removeAll()

--- a/build.sh
+++ b/build.sh
@@ -68,6 +68,17 @@ cp -R Frameworks/Sparkle.framework "$APP_BUNDLE/Contents/Frameworks/"
 cp -R Resources/web "$APP_BUNDLE/Contents/Resources/web"
 
 # -------- Build Quick Look extension --------
+echo "→ Compiling mindle-mcp helper…"
+MCP_BIN="build/mindle-mcp"
+swiftc -O \
+  -target arm64-apple-macos14.0 \
+  -parse-as-library \
+  -framework Foundation \
+  Sources/MindleMCP/*.swift \
+  -o "$MCP_BIN"
+
+cp "$MCP_BIN" "$APP_BUNDLE/Contents/MacOS/mindle-mcp"
+
 echo "→ Compiling Quick Look extension…"
 EXT_BIN="build/MindleQuickLook"
 EXT_BUNDLE="$APP_BUNDLE/Contents/PlugIns/MindleQuickLook.appex"


### PR DESCRIPTION
## Summary
First slice of the v2.0 milestone — the MCP plumbing that lets Claude (or any other harness) ask Mindle questions over a real protocol. **Phase 1 only**, intentionally narrow: prove the round-trip with one tool, then layer on the annotation surface in Phase 2.

### Architecture decision: Mindle's MCP is read-only and Mindle-unique

`read_file` and `write_file` belong in the agent's own filesystem tools. Mindle's MCP only exposes what no other tool can — what's currently open, what the user has annotated, and (in Phase 2) the ability to mark an annotation as addressed. The whole MCP becomes "the human's side of an agent collaboration loop, full stop."

### What's in this PR

- **`MCPServer` actor** in `Sources/mindle/MCPServer.swift`. Binds a Unix socket at `~/Library/Caches/local.fnp.mindle/mcp.sock` on launch, unlinks it on terminate. Speaks length-prefixed JSON internally — *not* MCP; the helper handles MCP framing.
- **AppDelegate wiring.** New `registeredStores` list (weak refs) so `list_open_files` aggregates paths across every window. `applicationDidFinishLaunching` starts the server; `applicationWillTerminate` stops it.
- **`mindle-mcp` Swift CLI** in `Sources/MindleMCP/main.swift`. Synchronous POSIX-read stdin loop, newline-delimited JSON-RPC out, full MCP handshake (`initialize` / `tools/list` / `tools/call`). On `tools/call list_open_files`, opens the Unix socket, sends the internal op, formats the response as text content. Clean error if Mindle isn't running ("Open Mindle and try again").
- **Build wiring.** `build.sh` compiles the helper alongside the main app and embeds it at `Mindle.app/Contents/MacOS/mindle-mcp`.

### Smoke test (passes locally)

```
{
  printf '%s\n' '{"jsonrpc":"2.0","id":1,"method":"initialize","params":{}}'
  printf '%s\n' '{"jsonrpc":"2.0","id":2,"method":"tools/list"}'
  printf '%s\n' '{"jsonrpc":"2.0","id":3,"method":"tools/call","params":{"name":"list_open_files","arguments":{}}}'
} | /Applications/Mindle.app/Contents/MacOS/mindle-mcp
```

Returns proper `serverInfo`, the `list_open_files` schema, and the open file paths as text content.

### Coming in subsequent phases

- **Phase 2** — `get_annotations(path)` and `clear_annotation(id, summary)`. Summary attaches to the diff chip's hover.
- **Phase 3** — bundled `mindle-collaboration` skill at `docs/skills/mindle-collaboration.md` teaching the agent the loop and listing tools as deferred (zero context cost until first call).
- **Phase 4** — "Set Up MCP for Claude Code…" menu item that runs the install command for the user.
- **Phase 5** — theme polish, landing-page rewrite, demo video.

Part of [v2.0 roadmap](https://github.com/nonatofabio/mindle/blob/main/docs/v2-roadmap.md).