### PR TITLE
MCP Phase 2: annotations loop + Keep All banner

### DIFF
--- a/Resources/web/reader.css
+++ b/Resources/web/reader.css
@@ -511,6 +511,55 @@ html.mindle-print-mode .mindle-mermaid {
 .mindle-diff-added > :first-child { margin-top: 0; }
 .mindle-diff-added > :last-child  { margin-bottom: 0; }
 
+.mindle-diff-banner {
+  position: sticky;
+  top: 12px;
+  z-index: 50;
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 1em;
+  margin: 0 0 1.5em;
+  padding: 8px 14px;
+  background: var(--surface, var(--background));
+  border: 1px solid var(--rule);
+  border-radius: 6px;
+  box-shadow: 0 2px 12px rgba(0, 0, 0, 0.06);
+  backdrop-filter: blur(6px);
+  -webkit-backdrop-filter: blur(6px);
+  font: 12px/1.2 -apple-system, BlinkMacSystemFont, "SF Pro Text", system-ui, sans-serif;
+}
+
+.mindle-diff-banner-label {
+  color: var(--muted, var(--text));
+  font-weight: 500;
+}
+
+.mindle-diff-banner-actions {
+  display: flex;
+  gap: 0.5em;
+}
+
+.mindle-diff-banner button {
+  font: 12px/1 -apple-system, BlinkMacSystemFont, "SF Pro Text", system-ui, sans-serif;
+  font-weight: 500;
+  padding: 5px 12px;
+  border-radius: 4px;
+  border: 1px solid var(--rule);
+  background: var(--background);
+  color: var(--text);
+  cursor: pointer;
+}
+.mindle-diff-banner button:hover { background: var(--surface); }
+.mindle-diff-banner button[data-mindle-diff-action="accept-all"]:hover {
+  border-color: rgba(39, 174, 96, 0.55);
+  color: rgb(39, 130, 80);
+}
+.mindle-diff-banner button[data-mindle-diff-action="reject-all"]:hover {
+  border-color: rgba(192, 57, 43, 0.55);
+  color: rgb(160, 50, 40);
+}
+
 .mindle-diff-controls {
   display: flex;
   gap: 0.5em;
@@ -549,7 +598,8 @@ html.mindle-print-mode .mindle-diff-chunk {
   margin: 0 !important;
 }
 html.mindle-print-mode .mindle-diff-removed,
-html.mindle-print-mode .mindle-diff-controls {
+html.mindle-print-mode .mindle-diff-controls,
+html.mindle-print-mode .mindle-diff-banner {
   display: none !important;
 }
 html.mindle-print-mode .mindle-diff-added {

--- a/Resources/web/reader.js
+++ b/Resources/web/reader.js
@@ -237,7 +237,12 @@
     // Switching documents clears search state; annotations are replayed below.
     searchState = { query: "", current: 0, total: 0, matchSets: [] };
     await applyAll();
-    if (showDiff) attachDiffHandlers();
+    if (showDiff) {
+      attachDiffHandlers();
+      injectDiffBanner();
+    } else {
+      removeDiffBanner();
+    }
     reportSearchResult();
     if (preserveScroll) {
       // applyAll's mermaid pass can settle in another frame; restore on
@@ -327,6 +332,42 @@
       body + controls +
       '</div>' +
       "\n\n";
+  }
+
+  function removeDiffBanner() {
+    const existing = document.getElementById("mindle-diff-banner");
+    if (existing) existing.remove();
+  }
+
+  // Sticky banner at the top of the article when a diff is in flight.
+  // Gives users a one-click path to keep or revert every chunk at once
+  // instead of clicking through each pair — the inline buttons remain
+  // for granular review.
+  function injectDiffBanner() {
+    removeDiffBanner();
+    const count = diffChunks.length;
+    if (count === 0) return;
+    const banner = document.createElement("div");
+    banner.id = "mindle-diff-banner";
+    banner.className = "mindle-diff-banner";
+    const noun = count === 1 ? "change" : "changes";
+    banner.innerHTML =
+      '<span class="mindle-diff-banner-label">' + count + ' pending ' + noun + '</span>' +
+      '<span class="mindle-diff-banner-actions">' +
+        '<button data-mindle-diff-action="accept-all">✓ Keep All</button>' +
+        '<button data-mindle-diff-action="reject-all">✗ Revert All</button>' +
+      '</span>';
+    doc.insertBefore(banner, doc.firstChild);
+    banner.querySelector('[data-mindle-diff-action="accept-all"]')
+      .addEventListener("click", (ev) => {
+        ev.preventDefault();
+        postToSwift("diffAcceptAll", {});
+      });
+    banner.querySelector('[data-mindle-diff-action="reject-all"]')
+      .addEventListener("click", (ev) => {
+        ev.preventDefault();
+        postToSwift("diffRejectAll", {});
+      });
   }
 
   function attachDiffHandlers() {

--- a/Resources/web/reader.js
+++ b/Resources/web/reader.js
@@ -728,6 +728,17 @@
     }
 
     applySearchMarks();
+
+    // Re-attach diff affordances every render. applyAll() rebuilds
+    // doc.innerHTML from renderedHTML, which contains the inline
+    // ✓ Keep / ✗ Revert buttons as static HTML but no event handlers,
+    // and never has the banner. Any path that re-renders during an
+    // in-flight diff (annotation change, search update) must restore
+    // both — otherwise the buttons silently stop working.
+    if (diffChunks.length) {
+      attachDiffHandlers();
+      injectDiffBanner();
+    }
   }
 
   async function renderMermaidBlocks() {

--- a/Sources/MindleMCP/main.swift
+++ b/Sources/MindleMCP/main.swift
@@ -241,10 +241,31 @@ struct MindleMCP {
                     let id = (ann["id"] as? String) ?? "?"
                     let text = (ann["text"] as? String) ?? ""
                     let note = (ann["note"] as? String) ?? ""
-                    lines.append("\(i + 1). [id: \(id)]")
+                    let author = (ann["author"] as? String) ?? "user"
+                    let authorTag = author == "agent" ? " (agent-authored)" : ""
+                    lines.append("\(i + 1). [id: \(id)]\(authorTag)")
                     lines.append("   Selected: \(text.replacingOccurrences(of: "\n", with: " "))")
                     if !note.isEmpty {
                         lines.append("   Note: \(note)")
+                    }
+                    if let thread = ann["thread"] as? [[String: Any]], !thread.isEmpty {
+                        lines.append("   Thread:")
+                        for msg in thread {
+                            let mAuthor = (msg["author"] as? String) ?? "?"
+                            let mText = (msg["text"] as? String) ?? ""
+                            // Indent multi-line messages under the bullet so
+                            // the agent can scan a long thread without losing
+                            // the author column.
+                            let firstLine: String
+                            let restLines: [String]
+                            let parts = mText.split(separator: "\n", omittingEmptySubsequences: false).map(String.init)
+                            firstLine = parts.first ?? ""
+                            restLines = Array(parts.dropFirst())
+                            lines.append("     - \(mAuthor): \(firstLine)")
+                            for r in restLines {
+                                lines.append("       \(r)")
+                            }
+                        }
                     }
                     lines.append("")
                 }

--- a/Sources/MindleMCP/main.swift
+++ b/Sources/MindleMCP/main.swift
@@ -149,6 +149,60 @@ struct MindleMCP {
                     "required": ["path", "id", "summary"],
                     "additionalProperties": false
                 ]
+            ],
+            [
+                "name": "comment_on_annotation",
+                "description": "Add a message to an annotation's thread without dismissing the annotation. Use this to reply to the user's note, ask a clarifying question before editing, or report progress on a multi-step change. The user sees your message inline under their annotation, with the same back-and-forth feel as a code review comment thread.",
+                "inputSchema": [
+                    "type": "object",
+                    "properties": [
+                        "path": [
+                            "type": "string",
+                            "description": "Absolute path to the file the annotation lives on."
+                        ],
+                        "id": [
+                            "type": "string",
+                            "description": "The annotation's UUID, as returned by get_annotations."
+                        ],
+                        "text": [
+                            "type": "string",
+                            "description": "Your message. Plain text. Keep it focused — one or two sentences usually."
+                        ]
+                    ],
+                    "required": ["path", "id", "text"],
+                    "additionalProperties": false
+                ]
+            ],
+            [
+                "name": "create_annotation",
+                "description": "Open a new annotation on a span of text in a file currently open in Mindle. Use this to ask the user a question about something you've written or about a passage you want their input on. The annotation appears in the user's sidebar marked as agent-authored with your note as the prompt; the user can reply in its thread.",
+                "inputSchema": [
+                    "type": "object",
+                    "properties": [
+                        "path": [
+                            "type": "string",
+                            "description": "Absolute path to the file. Must be currently open in Mindle."
+                        ],
+                        "text": [
+                            "type": "string",
+                            "description": "The exact substring of the file the annotation anchors to. Must appear verbatim in the current file content."
+                        ],
+                        "prefix": [
+                            "type": "string",
+                            "description": "Up to ~32 characters from the file immediately preceding 'text' — used to disambiguate when 'text' appears multiple times. Pass an empty string if the file is small and disambiguation isn't needed."
+                        ],
+                        "suffix": [
+                            "type": "string",
+                            "description": "Up to ~32 characters from the file immediately following 'text'."
+                        ],
+                        "note": [
+                            "type": "string",
+                            "description": "The question or comment you want the user to see. Will appear as the annotation's primary note above the thread."
+                        ]
+                    ],
+                    "required": ["path", "text", "prefix", "suffix", "note"],
+                    "additionalProperties": false
+                ]
             ]
         ]
     }
@@ -208,6 +262,35 @@ struct MindleMCP {
                 body: ["path": path, "id": id, "summary": summary]
             ) { _ in
                 return textContent("Cleared annotation \(id) on \(path).")
+            }
+
+        case "comment_on_annotation":
+            guard let path = arguments["path"] as? String,
+                  let id = arguments["id"] as? String,
+                  let text = arguments["text"] as? String else {
+                return errorContent("missing required arguments: path, id, text")
+            }
+            return callMindle(
+                op: "comment_on_annotation",
+                body: ["path": path, "id": id, "text": text]
+            ) { _ in
+                return textContent("Posted reply to annotation \(id) on \(path).")
+            }
+
+        case "create_annotation":
+            guard let path = arguments["path"] as? String,
+                  let text = arguments["text"] as? String,
+                  let note = arguments["note"] as? String else {
+                return errorContent("missing required arguments: path, text, note")
+            }
+            let prefix = (arguments["prefix"] as? String) ?? ""
+            let suffix = (arguments["suffix"] as? String) ?? ""
+            return callMindle(
+                op: "create_annotation",
+                body: ["path": path, "text": text, "prefix": prefix, "suffix": suffix, "note": note]
+            ) { resp in
+                let newID = (resp["id"] as? String) ?? "?"
+                return textContent("Opened annotation \(newID) on \(path).")
             }
 
         default:

--- a/Sources/MindleMCP/main.swift
+++ b/Sources/MindleMCP/main.swift
@@ -6,9 +6,10 @@ import Darwin
 // over the running Mindle's Unix socket, and emits the JSON-RPC response
 // on stdout.
 //
-// Read-only by design: Mindle exposes only what no other tool can —
-// open-files state and the annotation feedback channel. Filesystem reads
-// belong in the agent's normal Read tool, not here.
+// Mindle exposes only the annotation feedback channel — what's open,
+// what the user has annotated, and a way for the agent to mark an
+// annotation as addressed. File IO (reads, writes) belongs in the
+// agent's normal filesystem tools, not here.
 
 @main
 struct MindleMCP {
@@ -98,16 +99,54 @@ struct MindleMCP {
         ]
     }
 
-    // MARK: - Tool surface (Phase 1: list_open_files only)
+    // MARK: - Tool surface
 
     private static func toolDefinitions() -> [[String: Any]] {
         return [
             [
                 "name": "list_open_files",
-                "description": "List the absolute paths of every Markdown file currently open in Mindle (across all windows and tabs). Use this to see what the user is reading right now.",
+                "description": "List the absolute paths of every file currently open in Mindle (across all windows and tabs). Use this to see what the user is reading right now.",
                 "inputSchema": [
                     "type": "object",
                     "properties": [String: Any](),
+                    "additionalProperties": false
+                ]
+            ],
+            [
+                "name": "get_annotations",
+                "description": "Return every annotation (highlight or note) the user has placed on a file currently open in Mindle. Each annotation includes its id, the highlighted text verbatim, surrounding context, the user's note (often empty for plain highlights), and a creation timestamp. Use the annotation as the user's instruction to you: read it, address it with your normal file-editing tools, then call clear_annotation to mark it done.",
+                "inputSchema": [
+                    "type": "object",
+                    "properties": [
+                        "path": [
+                            "type": "string",
+                            "description": "Absolute path to the file. Must be a file currently open in Mindle — call list_open_files first if unsure."
+                        ]
+                    ],
+                    "required": ["path"],
+                    "additionalProperties": false
+                ]
+            ],
+            [
+                "name": "clear_annotation",
+                "description": "Mark an annotation as addressed and remove it from the file's sidebar. Provide a short summary of what you did so the user can see in their review pass. Call this after you've actually edited the file to address what the annotation asked for — clearing without addressing leaves the user confused.",
+                "inputSchema": [
+                    "type": "object",
+                    "properties": [
+                        "path": [
+                            "type": "string",
+                            "description": "Absolute path to the file the annotation lives on."
+                        ],
+                        "id": [
+                            "type": "string",
+                            "description": "The annotation's UUID, as returned by get_annotations."
+                        ],
+                        "summary": [
+                            "type": "string",
+                            "description": "One short sentence describing what you changed. Example: 'Rephrased the intro paragraph to be more concise.'"
+                        ]
+                    ],
+                    "required": ["path", "id", "summary"],
                     "additionalProperties": false
                 ]
             ]
@@ -118,6 +157,7 @@ struct MindleMCP {
         guard let name = params["name"] as? String else {
             return errorContent("missing tool name")
         }
+        let arguments = (params["arguments"] as? [String: Any]) ?? [:]
         switch name {
         case "list_open_files":
             return callMindle(op: "list_open_files", body: [:]) { resp in
@@ -130,6 +170,46 @@ struct MindleMCP {
                 let listing = files.map { "- \($0)" }.joined(separator: "\n")
                 return textContent("Files currently open in Mindle:\n\n\(listing)")
             }
+
+        case "get_annotations":
+            guard let path = arguments["path"] as? String else {
+                return errorContent("missing required argument: path")
+            }
+            return callMindle(op: "get_annotations", body: ["path": path]) { resp in
+                guard let anns = resp["annotations"] as? [[String: Any]] else {
+                    return errorContent("malformed response from Mindle")
+                }
+                if anns.isEmpty {
+                    return textContent("No annotations on \(path).")
+                }
+                var lines: [String] = ["Annotations on \(path):", ""]
+                for (i, ann) in anns.enumerated() {
+                    let id = (ann["id"] as? String) ?? "?"
+                    let text = (ann["text"] as? String) ?? ""
+                    let note = (ann["note"] as? String) ?? ""
+                    lines.append("\(i + 1). [id: \(id)]")
+                    lines.append("   Selected: \(text.replacingOccurrences(of: "\n", with: " "))")
+                    if !note.isEmpty {
+                        lines.append("   Note: \(note)")
+                    }
+                    lines.append("")
+                }
+                return textContent(lines.joined(separator: "\n"))
+            }
+
+        case "clear_annotation":
+            guard let path = arguments["path"] as? String,
+                  let id = arguments["id"] as? String,
+                  let summary = arguments["summary"] as? String else {
+                return errorContent("missing required arguments: path, id, summary")
+            }
+            return callMindle(
+                op: "clear_annotation",
+                body: ["path": path, "id": id, "summary": summary]
+            ) { _ in
+                return textContent("Cleared annotation \(id) on \(path).")
+            }
+
         default:
             return errorContent("unknown tool: \(name)")
         }

--- a/Sources/mindle/ContentView.swift
+++ b/Sources/mindle/ContentView.swift
@@ -363,22 +363,38 @@ struct AnnotationCard: View {
     @State private var noteDraft: String = ""
     @State private var isEditing: Bool = false
     @FocusState private var noteFocused: Bool
-    /// NSEvent monitor installed for the lifetime of `noteFocused == true`.
-    /// Catches bare Return to commit; Shift+Return falls through and
-    /// inserts a newline like any other multi-line text editor.
+
+    @State private var replyDraft: String = ""
+    @State private var isReplying: Bool = false
+    @FocusState private var replyFocused: Bool
+
+    /// Single NSEvent monitor shared between the note editor and the
+    /// reply editor — only one of the two TextEditors can be focused
+    /// at a time, so the closure dispatches to whichever commit action
+    /// matches the current focus. Catches bare Return to commit;
+    /// Shift+Return falls through and inserts a newline.
     @State private var returnKeyMonitor: Any? = nil
+
+    private var isAgentAuthored: Bool { annotation.author == "agent" }
+    private var hasThread: Bool { (annotation.thread?.isEmpty == false) }
+    private var canReply: Bool { !annotation.note.isEmpty || hasThread }
 
     var body: some View {
         let c = store.theme.colors
         let isFocused = store.focusedAnnotation == annotation.id
-        let dotColor: Color = annotation.note.isEmpty ? c.highlight : c.highlightNote
+        let dotColor: Color = isAgentAuthored
+            ? c.muted
+            : (annotation.note.isEmpty ? c.highlight : c.highlightNote)
+        let typeLabel: String = isAgentAuthored
+            ? "Agent"
+            : (annotation.note.isEmpty ? "Highlight" : "Note")
 
         VStack(alignment: .leading, spacing: 8) {
             HStack(spacing: 8) {
                 Circle()
                     .fill(dotColor)
                     .frame(width: 8, height: 8)
-                Text(annotation.note.isEmpty ? "Highlight" : "Note")
+                Text(typeLabel)
                     .font(.system(size: 10, weight: .semibold))
                     .foregroundStyle(c.muted)
                     .textCase(.uppercase)
@@ -463,6 +479,57 @@ struct AnnotationCard: View {
                 }
                 .buttonStyle(.plain)
             }
+
+            if let thread = annotation.thread, !thread.isEmpty {
+                VStack(alignment: .leading, spacing: 8) {
+                    ForEach(thread) { message in
+                        AnnotationMessageRow(message: message)
+                    }
+                }
+                .padding(.top, 2)
+            }
+
+            if isReplying {
+                TextEditor(text: $replyDraft)
+                    .font(.system(size: 12, design: .serif))
+                    .foregroundStyle(c.text)
+                    .scrollContentBackground(.hidden)
+                    .background(c.background.opacity(0.5))
+                    .frame(minHeight: 48, maxHeight: 120)
+                    .padding(6)
+                    .overlay(
+                        RoundedRectangle(cornerRadius: 5)
+                            .stroke(c.accent.opacity(0.45), lineWidth: 0.5)
+                    )
+                    .focused($replyFocused)
+                HStack {
+                    Spacer()
+                    Button("Cancel") { cancelReply() }
+                        .buttonStyle(.borderless)
+                        .font(.system(size: 11))
+                        .foregroundStyle(c.muted)
+                    Button("Send") { commitReply() }
+                        .buttonStyle(.borderless)
+                        .font(.system(size: 11, weight: .medium))
+                        .foregroundStyle(c.accent)
+                        .disabled(replyDraft.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty)
+                }
+            } else if canReply {
+                Button {
+                    isReplying = true
+                    DispatchQueue.main.asyncAfter(deadline: .now() + 0.05) {
+                        replyFocused = true
+                    }
+                } label: {
+                    HStack(spacing: 4) {
+                        Image(systemName: "arrowshape.turn.up.left")
+                        Text("Reply")
+                    }
+                    .font(.system(size: 11, weight: .medium))
+                    .foregroundStyle(c.accent)
+                }
+                .buttonStyle(.plain)
+            }
         }
         .padding(12)
         .background(
@@ -498,9 +565,8 @@ struct AnnotationCard: View {
                 }
             }
         }
-        .onChange(of: noteFocused) { _, focused in
-            if focused { installReturnMonitor() } else { removeReturnMonitor() }
-        }
+        .onChange(of: noteFocused) { _, _ in syncReturnMonitor() }
+        .onChange(of: replyFocused) { _, _ in syncReturnMonitor() }
         .onDisappear { removeReturnMonitor() }
     }
 
@@ -510,11 +576,40 @@ struct AnnotationCard: View {
         store.editingAnnotationID = nil
     }
 
+    private func commitReply() {
+        let trimmed = replyDraft.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !trimmed.isEmpty, let url = store.fileURL else { cancelReply(); return }
+        store.appendThreadMessage(
+            forPath: url.path,
+            annotationID: annotation.id,
+            author: "user",
+            text: replyDraft
+        )
+        replyDraft = ""
+        cancelReply()
+    }
+
+    private func cancelReply() {
+        isReplying = false
+        replyFocused = false
+        replyDraft = ""
+    }
+
     /// Local keyDown monitor. SwiftUI's TextEditor wraps an NSTextView
     /// that insists on inserting a newline for Return; the monitor sees
     /// the event first and can swallow it when no Shift is held,
     /// routing instead to commit. Shift+Return falls through to the
-    /// TextEditor's default newline insertion.
+    /// TextEditor's default newline insertion. One monitor serves both
+    /// fields; the closure dispatches based on which @FocusState is
+    /// currently true at the time of the press.
+    private func syncReturnMonitor() {
+        if noteFocused || replyFocused {
+            installReturnMonitor()
+        } else {
+            removeReturnMonitor()
+        }
+    }
+
     private func installReturnMonitor() {
         guard returnKeyMonitor == nil else { return }
         returnKeyMonitor = NSEvent.addLocalMonitorForEvents(matching: .keyDown) { event in
@@ -522,8 +617,9 @@ struct AnnotationCard: View {
             guard isReturn, !event.modifierFlags.contains(.shift) else {
                 return event
             }
-            commitNote()
-            return nil
+            if replyFocused { commitReply(); return nil }
+            if noteFocused { commitNote(); return nil }
+            return event
         }
     }
 
@@ -533,6 +629,42 @@ struct AnnotationCard: View {
             returnKeyMonitor = nil
         }
     }
+}
+
+/// One message row inside an annotation's thread. Single-column stack,
+/// each row anchored by a thin colored left stripe — gray for agent,
+/// accent for user. Picked for density: a working thread can have many
+/// short exchanges and bubbles would push relevant content off-screen.
+struct AnnotationMessageRow: View {
+    let message: AnnotationMessage
+    @EnvironmentObject var store: DocumentStore
+
+    var body: some View {
+        let c = store.theme.colors
+        let isAgent = message.author == "agent"
+        let stripeColor = isAgent ? c.muted : c.accent
+        HStack(alignment: .top, spacing: 8) {
+            Rectangle()
+                .fill(stripeColor.opacity(isAgent ? 0.55 : 0.9))
+                .frame(width: isAgent ? 1.5 : 2.5)
+            VStack(alignment: .leading, spacing: 3) {
+                Text(message.text)
+                    .font(.system(size: 12, design: .serif))
+                    .foregroundStyle(c.text)
+                    .fixedSize(horizontal: false, vertical: true)
+                Text(Self.timeFormatter.string(from: message.createdAt))
+                    .font(.system(size: 10))
+                    .foregroundStyle(c.muted)
+            }
+        }
+    }
+
+    private static let timeFormatter: DateFormatter = {
+        let f = DateFormatter()
+        f.dateStyle = .none
+        f.timeStyle = .short
+        return f
+    }()
 }
 
 // MARK: - File browser sidebar

--- a/Sources/mindle/ContentView.swift
+++ b/Sources/mindle/ContentView.swift
@@ -363,6 +363,10 @@ struct AnnotationCard: View {
     @State private var noteDraft: String = ""
     @State private var isEditing: Bool = false
     @FocusState private var noteFocused: Bool
+    /// NSEvent monitor installed for the lifetime of `noteFocused == true`.
+    /// Catches bare Return to commit; Shift+Return falls through and
+    /// inserts a newline like any other multi-line text editor.
+    @State private var returnKeyMonitor: Any? = nil
 
     var body: some View {
         let c = store.theme.colors
@@ -432,11 +436,7 @@ struct AnnotationCard: View {
                 if isEditing {
                     HStack {
                         Spacer()
-                        Button("Done") {
-                            isEditing = false
-                            noteFocused = false
-                            store.editingAnnotationID = nil
-                        }
+                        Button("Done") { commitNote() }
                         .buttonStyle(.borderless)
                         .font(.system(size: 11, weight: .medium))
                         .foregroundStyle(c.accent)
@@ -445,7 +445,14 @@ struct AnnotationCard: View {
             } else {
                 Button {
                     isEditing = true
-                    noteFocused = true
+                    // The TextEditor doesn't exist in the view tree until
+                    // isEditing flips to true; setting @FocusState in the
+                    // same tick is a no-op. Defer to the next runloop
+                    // pass so SwiftUI has built the field before we
+                    // request focus.
+                    DispatchQueue.main.asyncAfter(deadline: .now() + 0.05) {
+                        noteFocused = true
+                    }
                 } label: {
                     HStack(spacing: 4) {
                         Image(systemName: "plus")
@@ -471,7 +478,13 @@ struct AnnotationCard: View {
             noteDraft = annotation.note
             if store.editingAnnotationID == annotation.id {
                 isEditing = true
-                noteFocused = true
+                // Defer focus the same way the onChange path does — on
+                // brand-new cards (annotation just appended via ⌘⇧N),
+                // the TextEditor isn't in the view tree yet at onAppear
+                // time so a same-tick noteFocused = true is dropped.
+                DispatchQueue.main.asyncAfter(deadline: .now() + 0.08) {
+                    noteFocused = true
+                }
             }
         }
         .onChange(of: annotation.note) { _, newValue in
@@ -484,6 +497,40 @@ struct AnnotationCard: View {
                     noteFocused = true
                 }
             }
+        }
+        .onChange(of: noteFocused) { _, focused in
+            if focused { installReturnMonitor() } else { removeReturnMonitor() }
+        }
+        .onDisappear { removeReturnMonitor() }
+    }
+
+    private func commitNote() {
+        isEditing = false
+        noteFocused = false
+        store.editingAnnotationID = nil
+    }
+
+    /// Local keyDown monitor. SwiftUI's TextEditor wraps an NSTextView
+    /// that insists on inserting a newline for Return; the monitor sees
+    /// the event first and can swallow it when no Shift is held,
+    /// routing instead to commit. Shift+Return falls through to the
+    /// TextEditor's default newline insertion.
+    private func installReturnMonitor() {
+        guard returnKeyMonitor == nil else { return }
+        returnKeyMonitor = NSEvent.addLocalMonitorForEvents(matching: .keyDown) { event in
+            let isReturn = event.keyCode == 36 || event.keyCode == 76
+            guard isReturn, !event.modifierFlags.contains(.shift) else {
+                return event
+            }
+            commitNote()
+            return nil
+        }
+    }
+
+    private func removeReturnMonitor() {
+        if let m = returnKeyMonitor {
+            NSEvent.removeMonitor(m)
+            returnKeyMonitor = nil
         }
     }
 }

--- a/Sources/mindle/DocumentStore.swift
+++ b/Sources/mindle/DocumentStore.swift
@@ -7,6 +7,20 @@ enum ReaderTheme: String, CaseIterable, Codable {
     case light, sepia, dark
 }
 
+/// A message in an annotation's thread. Threads are how the user and
+/// the agent have a back-and-forth about a passage — the agent can
+/// post progress notes or questions, the user can reply, all anchored
+/// to the same passage.
+struct AnnotationMessage: Identifiable, Codable, Equatable {
+    var id: UUID = UUID()
+    /// "user" or "agent". Future authors (e.g., "system") can be added
+    /// without breaking the codec; readers should treat unknown values
+    /// as user.
+    var author: String
+    var text: String
+    var createdAt: Date = Date()
+}
+
 struct Annotation: Identifiable, Codable, Equatable {
     var id: UUID = UUID()
     var text: String        // the selected passage verbatim
@@ -14,6 +28,14 @@ struct Annotation: Identifiable, Codable, Equatable {
     var suffix: String      // ~32 chars after
     var note: String
     var createdAt: Date = Date()
+    /// nil means user-created — the default for every annotation made
+    /// before threads existed. Agent-created annotations get "agent"
+    /// so the UI can mark them distinctly.
+    var author: String?
+    /// Optional follow-up messages. Stored nil (not []) when there are
+    /// no replies so existing sidecars round-trip without growth and
+    /// the JSON stays minimal for the common case.
+    var thread: [AnnotationMessage]?
 }
 
 struct FileNode: Identifiable, Equatable {
@@ -389,6 +411,77 @@ final class DocumentStore: ObservableObject {
         }
         if let tab = tabs.first(where: { $0.fileURL.path == path }) {
             return tab.annotations
+        }
+        return nil
+    }
+
+    /// MCP-side: append a message to an existing annotation's thread.
+    /// Returns true if a matching annotation was found in any tab and
+    /// the message was appended.
+    @discardableResult
+    func appendThreadMessage(
+        forPath path: String,
+        annotationID: UUID,
+        author: String,
+        text: String
+    ) -> Bool {
+        let message = AnnotationMessage(author: author, text: text)
+        if let active = activeTabID,
+           let i = tabs.firstIndex(where: { $0.id == active }),
+           tabs[i].fileURL.path == path {
+            guard let j = annotations.firstIndex(where: { $0.id == annotationID }) else {
+                return false
+            }
+            var thread = annotations[j].thread ?? []
+            thread.append(message)
+            annotations[j].thread = thread
+            saveSidecar()
+            return true
+        }
+        if let i = tabs.firstIndex(where: { $0.fileURL.path == path }) {
+            guard let j = tabs[i].annotations.firstIndex(where: { $0.id == annotationID }) else {
+                return false
+            }
+            var thread = tabs[i].annotations[j].thread ?? []
+            thread.append(message)
+            tabs[i].annotations[j].thread = thread
+            saveSidecar(forTab: tabs[i])
+            return true
+        }
+        return false
+    }
+
+    /// MCP-side: create a new annotation authored by the agent. The
+    /// agent supplies the anchor (text+prefix+suffix) and the note,
+    /// just like a user creating one via ⌘⇧N. Returns the new
+    /// annotation's id, or nil if the file isn't open in this store.
+    func createAgentAnnotation(
+        forPath path: String,
+        text: String,
+        prefix: String,
+        suffix: String,
+        note: String
+    ) -> UUID? {
+        let ann = Annotation(
+            text: text,
+            prefix: prefix,
+            suffix: suffix,
+            note: note,
+            author: "agent",
+            thread: nil
+        )
+        if let active = activeTabID,
+           let i = tabs.firstIndex(where: { $0.id == active }),
+           tabs[i].fileURL.path == path {
+            annotations.append(ann)
+            showAnnotations = true
+            saveSidecar()
+            return ann.id
+        }
+        if let i = tabs.firstIndex(where: { $0.fileURL.path == path }) {
+            tabs[i].annotations.append(ann)
+            saveSidecar(forTab: tabs[i])
+            return ann.id
         }
         return nil
     }

--- a/Sources/mindle/DocumentStore.swift
+++ b/Sources/mindle/DocumentStore.swift
@@ -377,6 +377,49 @@ final class DocumentStore: ObservableObject {
         saveSidecar()
     }
 
+    /// MCP-side annotation lookup. Returns the annotations for whichever
+    /// tab in this window has `fileURL.path == path`, or nil if no tab
+    /// matches. Caller (AppDelegate) iterates every store to find a hit.
+    func annotations(forPath path: String) -> [Annotation]? {
+        if let active = activeTabID,
+           let tab = tabs.first(where: { $0.id == active }),
+           tab.fileURL.path == path {
+            // Active tab — in-memory annotations are authoritative.
+            return annotations
+        }
+        if let tab = tabs.first(where: { $0.fileURL.path == path }) {
+            return tab.annotations
+        }
+        return nil
+    }
+
+    /// MCP-side annotation clear. Removes the annotation with the given
+    /// id from the matching tab and persists the sidecar. Returns true
+    /// if a tab matched and the annotation was found+removed. The
+    /// summary is stashed in NSLog for now — Phase 3 surfaces it in the
+    /// UI as a chip next to the corresponding diff chunk.
+    @discardableResult
+    func removeAnnotation(forPath path: String, id: UUID, summary: String) -> Bool {
+        NSLog("[mindle.mcp] clear_annotation path=%@ id=%@ summary=%@", path, id.uuidString, summary)
+        if let active = activeTabID,
+           let i = tabs.firstIndex(where: { $0.id == active }),
+           tabs[i].fileURL.path == path {
+            guard annotations.contains(where: { $0.id == id }) else { return false }
+            annotations.removeAll { $0.id == id }
+            // saveSidecar() pulls from in-memory annotations of the
+            // active tab, so this persists correctly.
+            saveSidecar()
+            return true
+        }
+        if let i = tabs.firstIndex(where: { $0.fileURL.path == path }) {
+            guard tabs[i].annotations.contains(where: { $0.id == id }) else { return false }
+            tabs[i].annotations.removeAll { $0.id == id }
+            saveSidecar(forTab: tabs[i])
+            return true
+        }
+        return false
+    }
+
     func jumpTo(id: UUID) {
         focusedAnnotation = id
     }

--- a/Sources/mindle/MCPServer.swift
+++ b/Sources/mindle/MCPServer.swift
@@ -160,21 +160,82 @@ final class MCPServer {
                 guard let anns = AppDelegate.shared?.annotations(forPath: normalized) else {
                     return nil
                 }
+                let iso = ISO8601DateFormatter()
                 return anns.map { ann -> [String: Any] in
-                    [
+                    var payload: [String: Any] = [
                         "id": ann.id.uuidString,
                         "text": ann.text,
                         "prefix": ann.prefix,
                         "suffix": ann.suffix,
                         "note": ann.note,
-                        "createdAt": ISO8601DateFormatter().string(from: ann.createdAt)
+                        "author": ann.author ?? "user",
+                        "createdAt": iso.string(from: ann.createdAt)
                     ]
+                    if let thread = ann.thread, !thread.isEmpty {
+                        payload["thread"] = thread.map { msg -> [String: Any] in
+                            [
+                                "id": msg.id.uuidString,
+                                "author": msg.author,
+                                "text": msg.text,
+                                "createdAt": iso.string(from: msg.createdAt)
+                            ]
+                        }
+                    }
+                    return payload
                 }
             }
             guard let annotations = result else {
                 return ["ok": false, "error": "file not open in Mindle: \(path)"]
             }
             return ["ok": true, "annotations": annotations]
+
+        case "comment_on_annotation":
+            guard let path = request["path"] as? String else {
+                return ["ok": false, "error": "missing 'path'"]
+            }
+            guard let idStr = request["id"] as? String, let id = UUID(uuidString: idStr) else {
+                return ["ok": false, "error": "missing or malformed 'id' (expected UUID string)"]
+            }
+            guard let text = request["text"] as? String, !text.isEmpty else {
+                return ["ok": false, "error": "missing or empty 'text'"]
+            }
+            let normalized = URL(fileURLWithPath: path).standardizedFileURL.path
+            let appended = await MainActor.run {
+                AppDelegate.shared?.appendThreadMessage(
+                    forPath: normalized, annotationID: id, author: "agent", text: text
+                ) ?? false
+            }
+            if appended {
+                return ["ok": true]
+            }
+            return ["ok": false, "error": "annotation not found (file may not be open or id is stale)"]
+
+        case "create_annotation":
+            guard let path = request["path"] as? String else {
+                return ["ok": false, "error": "missing 'path'"]
+            }
+            guard let text = request["text"] as? String, !text.isEmpty else {
+                return ["ok": false, "error": "missing or empty 'text'"]
+            }
+            guard let note = request["note"] as? String else {
+                return ["ok": false, "error": "missing 'note'"]
+            }
+            let prefix = (request["prefix"] as? String) ?? ""
+            let suffix = (request["suffix"] as? String) ?? ""
+            let normalized = URL(fileURLWithPath: path).standardizedFileURL.path
+            let newID = await MainActor.run {
+                AppDelegate.shared?.createAgentAnnotation(
+                    forPath: normalized,
+                    text: text,
+                    prefix: prefix,
+                    suffix: suffix,
+                    note: note
+                )
+            }
+            if let id = newID {
+                return ["ok": true, "id": id.uuidString]
+            }
+            return ["ok": false, "error": "file not open in Mindle: \(path)"]
 
         case "clear_annotation":
             guard let path = request["path"] as? String else {

--- a/Sources/mindle/MCPServer.swift
+++ b/Sources/mindle/MCPServer.swift
@@ -150,6 +150,51 @@ final class MCPServer {
         case "list_open_files":
             let files = await MainActor.run { AppDelegate.shared?.allOpenFilePaths() ?? [] }
             return ["ok": true, "files": files]
+
+        case "get_annotations":
+            guard let path = request["path"] as? String else {
+                return ["ok": false, "error": "missing 'path'"]
+            }
+            let normalized = URL(fileURLWithPath: path).standardizedFileURL.path
+            let result: [[String: Any]]? = await MainActor.run {
+                guard let anns = AppDelegate.shared?.annotations(forPath: normalized) else {
+                    return nil
+                }
+                return anns.map { ann -> [String: Any] in
+                    [
+                        "id": ann.id.uuidString,
+                        "text": ann.text,
+                        "prefix": ann.prefix,
+                        "suffix": ann.suffix,
+                        "note": ann.note,
+                        "createdAt": ISO8601DateFormatter().string(from: ann.createdAt)
+                    ]
+                }
+            }
+            guard let annotations = result else {
+                return ["ok": false, "error": "file not open in Mindle: \(path)"]
+            }
+            return ["ok": true, "annotations": annotations]
+
+        case "clear_annotation":
+            guard let path = request["path"] as? String else {
+                return ["ok": false, "error": "missing 'path'"]
+            }
+            guard let idStr = request["id"] as? String, let id = UUID(uuidString: idStr) else {
+                return ["ok": false, "error": "missing or malformed 'id' (expected UUID string)"]
+            }
+            let summary = (request["summary"] as? String) ?? ""
+            let normalized = URL(fileURLWithPath: path).standardizedFileURL.path
+            let removed = await MainActor.run {
+                AppDelegate.shared?.clearAnnotation(
+                    forPath: normalized, id: id, summary: summary
+                ) ?? false
+            }
+            if removed {
+                return ["ok": true]
+            }
+            return ["ok": false, "error": "annotation not found (file may not be open or id is stale)"]
+
         default:
             return ["ok": false, "error": "unknown op: \(op)"]
         }

--- a/Sources/mindle/MindleApp.swift
+++ b/Sources/mindle/MindleApp.swift
@@ -59,6 +59,35 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
         return ordered
     }
 
+    /// Find the first store that has `path` open and return its
+    /// annotations. Returns nil if the file isn't open in any window —
+    /// the agent should first call `list_open_files` to see what's
+    /// available.
+    func annotations(forPath path: String) -> [Annotation]? {
+        registeredStores.removeAll { $0.store == nil }
+        for ref in registeredStores {
+            if let anns = ref.store?.annotations(forPath: path) {
+                return anns
+            }
+        }
+        return nil
+    }
+
+    /// Remove the annotation with the given id from whichever store has
+    /// the file open. Returns true on success. The summary captures the
+    /// agent's description of what it did to address the annotation —
+    /// stashed for now, surfaced in the UI in Phase 3.
+    func clearAnnotation(forPath path: String, id: UUID, summary: String) -> Bool {
+        registeredStores.removeAll { $0.store == nil }
+        for ref in registeredStores {
+            guard let store = ref.store else { continue }
+            if store.removeAnnotation(forPath: path, id: id, summary: summary) {
+                return true
+            }
+        }
+        return false
+    }
+
     func application(_ sender: NSApplication, open urls: [URL]) {
         if let store = activeStore {
             for url in urls {

--- a/Sources/mindle/MindleApp.swift
+++ b/Sources/mindle/MindleApp.swift
@@ -88,6 +88,53 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
         return false
     }
 
+    /// Append a message to an existing annotation's thread, in
+    /// whichever window has the file open.
+    func appendThreadMessage(
+        forPath path: String,
+        annotationID: UUID,
+        author: String,
+        text: String
+    ) -> Bool {
+        registeredStores.removeAll { $0.store == nil }
+        for ref in registeredStores {
+            if ref.store?.appendThreadMessage(
+                forPath: path,
+                annotationID: annotationID,
+                author: author,
+                text: text
+            ) == true {
+                return true
+            }
+        }
+        return false
+    }
+
+    /// Create a new agent-authored annotation in whichever window has
+    /// the file open. Returns the new annotation's id, or nil if the
+    /// file isn't open in any window.
+    func createAgentAnnotation(
+        forPath path: String,
+        text: String,
+        prefix: String,
+        suffix: String,
+        note: String
+    ) -> UUID? {
+        registeredStores.removeAll { $0.store == nil }
+        for ref in registeredStores {
+            if let id = ref.store?.createAgentAnnotation(
+                forPath: path,
+                text: text,
+                prefix: prefix,
+                suffix: suffix,
+                note: note
+            ) {
+                return id
+            }
+        }
+        return nil
+    }
+
     func application(_ sender: NSApplication, open urls: [URL]) {
         if let store = activeStore {
             for url in urls {

--- a/Sources/mindle/WebReaderView.swift
+++ b/Sources/mindle/WebReaderView.swift
@@ -14,6 +14,8 @@ struct WebReaderView: NSViewRepresentable {
         userContent.add(context.coordinator, name: "searchResult")
         userContent.add(context.coordinator, name: "diffSetLastSynced")
         userContent.add(context.coordinator, name: "diffSetCurrent")
+        userContent.add(context.coordinator, name: "diffAcceptAll")
+        userContent.add(context.coordinator, name: "diffRejectAll")
         config.userContentController = userContent
         config.setURLSchemeHandler(ImageSchemeHandler(), forURLScheme: ImageSchemeHandler.scheme)
         config.defaultWebpagePreferences.allowsContentJavaScript = true
@@ -294,6 +296,16 @@ struct WebReaderView: NSViewRepresentable {
                       let text = body["text"] as? String else { return }
                 Task { @MainActor in
                     self.parent.store.setRawText(text)
+                }
+
+            case "diffAcceptAll":
+                Task { @MainActor in
+                    self.parent.store.acceptAllChanges()
+                }
+
+            case "diffRejectAll":
+                Task { @MainActor in
+                    self.parent.store.rejectAllChanges()
                 }
 
             default: break


### PR DESCRIPTION
## Summary

Builds on #9 (Phase 1 commits are included until that PR merges, then this rebases cleanly).

- **`get_annotations(path)`** — agent reads the user's annotations on an open file
- **`clear_annotation(path, id, summary)`** — agent marks an annotation as addressed; summary stashed via NSLog (Phase 3 will surface it as a chip on the diff chunk)
- **Keep All / Revert All banner** — sticky bar at the top of the article whenever a diff is in flight, fixing the pain of clicking through many inline chunk buttons. ⌘⌥⏎ and ⌘⌥⌫ keyboard shortcuts still work; the banner is the discoverable path.

The full collaboration loop now hangs together: user annotates → agent reads via `get_annotations` → agent edits the file with its own filesystem tools → file watcher fires the diff in Mindle → agent calls `clear_annotation` → user reviews diff and hits Keep All.

## Test plan

- [ ] Open a file in Mindle, no annotations: `get_annotations` returns "No annotations on <path>."
- [ ] Highlight a paragraph in Mindle → `get_annotations` returns the highlight with text/prefix/suffix/id
- [ ] Have the agent edit the file → diff appears in Mindle with new banner showing "N pending changes"
- [ ] Click "Keep All" in banner → all diff chunks accepted in one shot, baseline syncs
- [ ] Click "Revert All" → file rewrites to baseline, diff clears
- [ ] `clear_annotation` with the highlight id → annotation disappears from Mindle sidebar
- [ ] `clear_annotation` with stale id → returns "annotation not found"
- [ ] PDF export with diff active → banner hidden in printed output