### PR TITLE
MCP Phase 3: wait_for_annotation_event for ambient collaboration

### DIFF
--- a/Sources/MindleMCP/main.swift
+++ b/Sources/MindleMCP/main.swift
@@ -14,6 +14,11 @@ import Darwin
 @main
 struct MindleMCP {
 
+    /// Stable UUID for the lifetime of this helper process. Threaded into
+    /// every Mindle request so Mindle can tag mutations and filter them
+    /// back out of wait_for_annotation_event responses for the same client.
+    private static let clientID: String = UUID().uuidString
+
     static func main() {
         // Synchronous read loop — async/Task on stdin proved flaky in
         // this CLI context. POSIX read on fd 0 is bulletproof.
@@ -382,6 +387,7 @@ struct MindleMCP {
 
         var request = body
         request["op"] = op
+        request["client_id"] = clientID
         guard let data = try? JSONSerialization.data(withJSONObject: request) else {
             return errorContent("could not encode request")
         }

--- a/Sources/MindleMCP/main.swift
+++ b/Sources/MindleMCP/main.swift
@@ -422,6 +422,11 @@ struct MindleMCP {
             return errorContent("socket() failed: \(String(cString: strerror(errno)))")
         }
         defer { close(fd) }
+        // SO_NOSIGPIPE: never let a write to a closed socket terminate
+        // this helper process. write() will return -1 with errno=EPIPE
+        // and writeAll surfaces that as a clean error.
+        var noSigPipe: Int32 = 1
+        setsockopt(fd, SOL_SOCKET, SO_NOSIGPIPE, &noSigPipe, socklen_t(MemoryLayout<Int32>.size))
 
         var addr = sockaddr_un()
         addr.sun_family = sa_family_t(AF_UNIX)

--- a/Sources/MindleMCP/main.swift
+++ b/Sources/MindleMCP/main.swift
@@ -208,6 +208,25 @@ struct MindleMCP {
                     "required": ["path", "text", "prefix", "suffix", "note"],
                     "additionalProperties": false
                 ]
+            ],
+            [
+                "name": "wait_for_annotation_event",
+                "description": "Long-poll for the next user annotation event in Mindle. Use this to run an ambient collaboration loop: the user annotates a file in Mindle, you wake up here with the event payload, address it (read context, edit the file, comment_on_annotation or clear_annotation as appropriate), then call wait_for_annotation_event again. Wakeup events are: a new annotation, a user reply in an existing thread, an annotation deletion. Your own mutations (clear_annotation, comment_on_annotation, create_annotation) never wake you. Before starting the loop, call list_open_files and get_annotations on each open file so you have baseline context. The result includes 'events' (possibly empty if the timeout elapsed — call again), 'last_event_id' (pass back as since_event_id), and 'gap' (true if events were dropped between calls — rebaseline with get_annotations).",
+                "inputSchema": [
+                    "type": "object",
+                    "properties": [
+                        "timeout_seconds": [
+                            "type": "number",
+                            "description": "How long to wait for an event before returning empty. Server clamps to [5, 300]. Default 60.",
+                            "default": 60
+                        ],
+                        "since_event_id": [
+                            "type": "integer",
+                            "description": "The last_event_id from your previous wait_for_annotation_event call. Pass null on the first call to wait for events from now forward."
+                        ]
+                    ],
+                    "additionalProperties": false
+                ]
             ]
         ]
     }
@@ -317,6 +336,48 @@ struct MindleMCP {
             ) { resp in
                 let newID = (resp["id"] as? String) ?? "?"
                 return textContent("Opened annotation \(newID) on \(path).")
+            }
+
+        case "wait_for_annotation_event":
+            var body: [String: Any] = [:]
+            if let t = arguments["timeout_seconds"] {
+                body["timeout_seconds"] = t
+            }
+            if let s = arguments["since_event_id"] {
+                body["since_event_id"] = s
+            }
+            return callMindle(op: "wait_for_annotation_event", body: body) { resp in
+                guard let events = resp["events"] as? [[String: Any]] else {
+                    return errorContent("malformed response from Mindle")
+                }
+                let lastEventID = (resp["last_event_id"] as? Int) ?? 0
+                let gap = (resp["gap"] as? Bool) ?? false
+                if events.isEmpty {
+                    let gapNote = gap ? " (gap=true; rebaseline via get_annotations)" : ""
+                    return textContent("No new events. last_event_id=\(lastEventID)\(gapNote)")
+                }
+                var lines: [String] = ["Events (last_event_id=\(lastEventID), gap=\(gap)):"]
+                for ev in events {
+                    let id = (ev["event_id"] as? Int) ?? 0
+                    let kind = (ev["type"] as? String) ?? "?"
+                    let path = (ev["path"] as? String) ?? "?"
+                    let annID = (ev["annotation_id"] as? String) ?? "?"
+                    lines.append("- [event \(id)] \(kind) on \(path) (annotation \(annID))")
+                    if let ann = ev["annotation"] as? [String: Any] {
+                        let note = (ann["note"] as? String) ?? ""
+                        if !note.isEmpty {
+                            lines.append("    Note: \(note)")
+                        }
+                        if let thread = ann["thread"] as? [[String: Any]], !thread.isEmpty {
+                            if let last = thread.last,
+                               let mAuthor = last["author"] as? String,
+                               let mText = last["text"] as? String {
+                                lines.append("    Latest message (\(mAuthor)): \(mText)")
+                            }
+                        }
+                    }
+                }
+                return textContent(lines.joined(separator: "\n"))
             }
 
         default:

--- a/Sources/mindle/AnnotationEventLog.swift
+++ b/Sources/mindle/AnnotationEventLog.swift
@@ -136,9 +136,20 @@ final class AnnotationEventLog {
             return snap
         }
 
+        // Pin the waiter's threshold at call time. With sinceID == nil
+        // we want "events appended AFTER this call returns" — but
+        // signalWaiters re-evaluates `snapshot(sinceID: nil)` on every
+        // append, and snapshot resolves nil to the current lastID
+        // (nextID - 1), which advances with each append. The result:
+        // every new event has id == new lastID and is filtered out by
+        // `ev.id > effectiveSince`, so the waiter never wakes. Resolve
+        // nil to the current lastID exactly once at registration so the
+        // threshold is fixed for the lifetime of this waiter.
+        let pinnedSinceID = sinceID ?? (nextID - 1)
+
         return await withCheckedContinuation { continuation in
             let waiter = Waiter(
-                sinceID: sinceID,
+                sinceID: pinnedSinceID,
                 excludingClientID: excludingClientID,
                 continuation: continuation
             )

--- a/Sources/mindle/AnnotationEventLog.swift
+++ b/Sources/mindle/AnnotationEventLog.swift
@@ -1,0 +1,93 @@
+import Foundation
+
+/// One entry in the cross-window event log. Mutations of any annotation
+/// (created, reply added to thread, deleted) become events. The agent
+/// pulls them through `MCPServer.wait_for_annotation_event` to drive
+/// an ambient collaboration loop.
+struct AnnotationEvent {
+    enum Kind: String {
+        case created
+        case threadReply = "thread_reply"
+        case deleted
+    }
+
+    let id: Int
+    let kind: Kind
+    let path: String
+    let annotationID: UUID
+    /// Full annotation payload for created/threadReply. nil for deleted —
+    /// the annotation no longer exists by the time consumers see it.
+    let annotation: Annotation?
+    /// For threadReply: the id of the new message. nil otherwise.
+    let messageID: UUID?
+    let occurredAt: Date
+    /// UUID of the MCP client whose mutation produced this event, or nil
+    /// for user UI actions. `wait_for_annotation_event` filters out
+    /// events whose clientID equals the caller's clientID — the agent
+    /// must not wake on its own writes.
+    let clientID: String?
+}
+
+/// MainActor-isolated event log. Ring-buffered to the last 256 events;
+/// older events drop and consumers that fall further behind receive a
+/// gap signal so they can rebaseline via get_annotations.
+@MainActor
+final class AnnotationEventLog {
+    static let shared = AnnotationEventLog()
+
+    private var events: [AnnotationEvent] = []
+    private var nextID: Int = 1
+    private let capacity: Int = 256
+
+    private init() {}
+
+    /// Append a new event. Caller supplies the payload (kind, path, etc.);
+    /// the log assigns the monotonic id and timestamp.
+    func append(
+        kind: AnnotationEvent.Kind,
+        path: String,
+        annotationID: UUID,
+        annotation: Annotation?,
+        messageID: UUID? = nil,
+        clientID: String?
+    ) {
+        let event = AnnotationEvent(
+            id: nextID,
+            kind: kind,
+            path: path,
+            annotationID: annotationID,
+            annotation: annotation,
+            messageID: messageID,
+            occurredAt: Date(),
+            clientID: clientID
+        )
+        nextID += 1
+        events.append(event)
+        if events.count > capacity {
+            events.removeFirst(events.count - capacity)
+        }
+    }
+
+    /// Read-only snapshot. Returns events with id > sinceID whose
+    /// clientID is not equal to `excludingClientID`. The caller uses
+    /// the result's `gap` to decide whether to rebaseline.
+    func snapshot(
+        sinceID: Int?,
+        excludingClientID: String?
+    ) -> (events: [AnnotationEvent], lastEventID: Int, gap: Bool) {
+        let lastID = (nextID - 1)
+        let oldestID = events.first?.id ?? 1
+        let effectiveSince = sinceID ?? lastID
+
+        let gap: Bool = {
+            if let since = sinceID, since < oldestID - 1 { return true }
+            return false
+        }()
+
+        let filtered = events.filter { ev in
+            ev.id > effectiveSince &&
+            ev.clientID != excludingClientID
+        }
+        return (filtered, lastID, gap)
+    }
+}

--- a/Sources/mindle/AnnotationEventLog.swift
+++ b/Sources/mindle/AnnotationEventLog.swift
@@ -39,6 +39,28 @@ final class AnnotationEventLog {
     private var nextID: Int = 1
     private let capacity: Int = 256
 
+    /// One pending wait() call. The continuation is resumed exactly once —
+    /// either by `signalWaiters()` when an event arrives that the waiter
+    /// cares about, or by the timeout task when `timeoutSeconds` elapses.
+    private final class Waiter {
+        let sinceID: Int?
+        let excludingClientID: String?
+        let continuation: CheckedContinuation<(events: [AnnotationEvent], lastEventID: Int, gap: Bool), Never>
+        var resumed: Bool = false
+
+        init(
+            sinceID: Int?,
+            excludingClientID: String?,
+            continuation: CheckedContinuation<(events: [AnnotationEvent], lastEventID: Int, gap: Bool), Never>
+        ) {
+            self.sinceID = sinceID
+            self.excludingClientID = excludingClientID
+            self.continuation = continuation
+        }
+    }
+
+    private var waiters: [Waiter] = []
+
     private init() {}
 
     /// Append a new event. Caller supplies the payload (kind, path, etc.);
@@ -66,6 +88,7 @@ final class AnnotationEventLog {
         if events.count > capacity {
             events.removeFirst(events.count - capacity)
         }
+        signalWaiters()
     }
 
     /// Read-only snapshot. Returns events with id > sinceID whose
@@ -89,5 +112,72 @@ final class AnnotationEventLog {
             ev.clientID != excludingClientID
         }
         return (filtered, lastID, gap)
+    }
+
+    /// Long-poll for the next event matching the filter. Returns the
+    /// current snapshot immediately if it already contains events the
+    /// caller hasn't seen; otherwise blocks for up to timeoutSeconds.
+    ///
+    /// Note: `sinceID == nil` means "from now" — only events appended
+    /// AFTER this call returns. This matches the spec's "agent calls
+    /// get_annotations to baseline, then watches for new events."
+    func wait(
+        sinceID: Int?,
+        timeoutSeconds: Double,
+        excludingClientID: String?
+    ) async -> (events: [AnnotationEvent], lastEventID: Int, gap: Bool) {
+        let snap = snapshot(sinceID: sinceID, excludingClientID: excludingClientID)
+        if !snap.events.isEmpty || snap.gap {
+            return snap
+        }
+
+        return await withCheckedContinuation { continuation in
+            let waiter = Waiter(
+                sinceID: sinceID,
+                excludingClientID: excludingClientID,
+                continuation: continuation
+            )
+            waiters.append(waiter)
+
+            Task { @MainActor in
+                try? await Task.sleep(nanoseconds: UInt64(timeoutSeconds * 1_000_000_000))
+                self.resume(waiter, withEmpty: true)
+            }
+        }
+    }
+
+    private func signalWaiters() {
+        let pending = waiters
+        for waiter in pending {
+            let snap = snapshot(
+                sinceID: waiter.sinceID,
+                excludingClientID: waiter.excludingClientID
+            )
+            if !snap.events.isEmpty || snap.gap {
+                resume(waiter, withEmpty: false)
+            }
+        }
+    }
+
+    private func resume(
+        _ waiter: Waiter,
+        withEmpty: Bool
+    ) {
+        guard !waiter.resumed else { return }
+        waiter.resumed = true
+        if let idx = waiters.firstIndex(where: { $0 === waiter }) {
+            waiters.remove(at: idx)
+        }
+        if withEmpty {
+            waiter.continuation.resume(
+                returning: ([], nextID - 1, false)
+            )
+        } else {
+            let snap = snapshot(
+                sinceID: waiter.sinceID,
+                excludingClientID: waiter.excludingClientID
+            )
+            waiter.continuation.resume(returning: snap)
+        }
     }
 }

--- a/Sources/mindle/AnnotationEventLog.swift
+++ b/Sources/mindle/AnnotationEventLog.swift
@@ -103,7 +103,12 @@ final class AnnotationEventLog {
         let effectiveSince = sinceID ?? lastID
 
         let gap: Bool = {
-            if let since = sinceID, since < oldestID - 1 { return true }
+            guard let since = sinceID else { return false }
+            // Agent fell off the back of the ring buffer — events were dropped.
+            if since < oldestID - 1 { return true }
+            // Agent is holding an id newer than anything we know about — this
+            // happens after a Mindle restart resets nextID. Force rebaseline.
+            if since > lastID { return true }
             return false
         }()
 

--- a/Sources/mindle/ContentView.swift
+++ b/Sources/mindle/ContentView.swift
@@ -371,6 +371,22 @@ struct AnnotationsSidebar: View {
                             }
                         }
                     }
+                    .onAppear {
+                        // Sidebar was closed when the user hit ⌘⇧N.
+                        // focusedAnnotation got set BEFORE the
+                        // ScrollViewReader existed, so .onChange
+                        // missed the transition. Catch the
+                        // already-set value here when the sidebar
+                        // finally mounts. Longer defer than .onChange
+                        // because we're also racing the sidebar's
+                        // open animation.
+                        guard let id = store.focusedAnnotation else { return }
+                        DispatchQueue.main.asyncAfter(deadline: .now() + 0.2) {
+                            withAnimation(.easeInOut(duration: 0.2)) {
+                                proxy.scrollTo(id, anchor: .center)
+                            }
+                        }
+                    }
                 }
             }
         }

--- a/Sources/mindle/ContentView.swift
+++ b/Sources/mindle/ContentView.swift
@@ -364,15 +364,10 @@ struct AnnotationCard: View {
     @State private var isEditing: Bool = false
     @FocusState private var noteFocused: Bool
 
-    @State private var replyDraft: String = ""
-    @State private var isReplying: Bool = false
-    @FocusState private var replyFocused: Bool
-
-    /// Single NSEvent monitor shared between the note editor and the
-    /// reply editor — only one of the two TextEditors can be focused
-    /// at a time, so the closure dispatches to whichever commit action
-    /// matches the current focus. Catches bare Return to commit;
-    /// Shift+Return falls through and inserts a newline.
+    /// NSEvent monitor for the note editor's Return-to-commit. The reply
+    /// box runs its own monitor inside AnnotationReplyBox so a thread
+    /// update from another author can't disturb the user's reply
+    /// composition.
     @State private var returnKeyMonitor: Any? = nil
 
     private var isAgentAuthored: Bool { annotation.author == "agent" }
@@ -489,46 +484,8 @@ struct AnnotationCard: View {
                 .padding(.top, 2)
             }
 
-            if isReplying {
-                TextEditor(text: $replyDraft)
-                    .font(.system(size: 12, design: .serif))
-                    .foregroundStyle(c.text)
-                    .scrollContentBackground(.hidden)
-                    .background(c.background.opacity(0.5))
-                    .frame(minHeight: 48, maxHeight: 120)
-                    .padding(6)
-                    .overlay(
-                        RoundedRectangle(cornerRadius: 5)
-                            .stroke(c.accent.opacity(0.45), lineWidth: 0.5)
-                    )
-                    .focused($replyFocused)
-                HStack {
-                    Spacer()
-                    Button("Cancel") { cancelReply() }
-                        .buttonStyle(.borderless)
-                        .font(.system(size: 11))
-                        .foregroundStyle(c.muted)
-                    Button("Send") { commitReply() }
-                        .buttonStyle(.borderless)
-                        .font(.system(size: 11, weight: .medium))
-                        .foregroundStyle(c.accent)
-                        .disabled(replyDraft.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty)
-                }
-            } else if canReply {
-                Button {
-                    isReplying = true
-                    DispatchQueue.main.asyncAfter(deadline: .now() + 0.05) {
-                        replyFocused = true
-                    }
-                } label: {
-                    HStack(spacing: 4) {
-                        Image(systemName: "arrowshape.turn.up.left")
-                        Text("Reply")
-                    }
-                    .font(.system(size: 11, weight: .medium))
-                    .foregroundStyle(c.accent)
-                }
-                .buttonStyle(.plain)
+            if canReply {
+                AnnotationReplyBox(annotationID: annotation.id)
             }
         }
         .padding(12)
@@ -565,8 +522,9 @@ struct AnnotationCard: View {
                 }
             }
         }
-        .onChange(of: noteFocused) { _, _ in syncReturnMonitor() }
-        .onChange(of: replyFocused) { _, _ in syncReturnMonitor() }
+        .onChange(of: noteFocused) { _, focused in
+            if focused { installReturnMonitor() } else { removeReturnMonitor() }
+        }
         .onDisappear { removeReturnMonitor() }
     }
 
@@ -576,38 +534,111 @@ struct AnnotationCard: View {
         store.editingAnnotationID = nil
     }
 
-    private func commitReply() {
-        let trimmed = replyDraft.trimmingCharacters(in: .whitespacesAndNewlines)
-        guard !trimmed.isEmpty, let url = store.fileURL else { cancelReply(); return }
+    /// Local keyDown monitor for the note editor only. The reply box
+    /// owns its own monitor so its lifecycle is independent of any
+    /// other state on this card.
+    private func installReturnMonitor() {
+        guard returnKeyMonitor == nil else { return }
+        returnKeyMonitor = NSEvent.addLocalMonitorForEvents(matching: .keyDown) { event in
+            let isReturn = event.keyCode == 36 || event.keyCode == 76
+            guard isReturn, !event.modifierFlags.contains(.shift) else {
+                return event
+            }
+            if noteFocused { commitNote(); return nil }
+            return event
+        }
+    }
+
+    private func removeReturnMonitor() {
+        if let m = returnKeyMonitor {
+            NSEvent.removeMonitor(m)
+            returnKeyMonitor = nil
+        }
+    }
+}
+
+/// Reply composer for one annotation. Lives as its own SwiftUI view
+/// so its @State and @FocusState are isolated from re-renders driven
+/// by thread updates on the parent AnnotationCard. When another
+/// author (the agent) posts to the thread, the AnnotationCard rebuilds
+/// — but this box keeps its draft, its composing state, and the
+/// focused TextEditor as-is. Typing keeps working.
+struct AnnotationReplyBox: View {
+    let annotationID: UUID
+    @EnvironmentObject var store: DocumentStore
+    @State private var draft: String = ""
+    @State private var isComposing: Bool = false
+    @FocusState private var focused: Bool
+    @State private var returnKeyMonitor: Any? = nil
+
+    var body: some View {
+        let c = store.theme.colors
+        VStack(alignment: .leading, spacing: 6) {
+            if isComposing {
+                TextEditor(text: $draft)
+                    .font(.system(size: 12, design: .serif))
+                    .foregroundStyle(c.text)
+                    .scrollContentBackground(.hidden)
+                    .background(c.background.opacity(0.5))
+                    .frame(minHeight: 48, maxHeight: 120)
+                    .padding(6)
+                    .overlay(
+                        RoundedRectangle(cornerRadius: 5)
+                            .stroke(c.accent.opacity(0.45), lineWidth: 0.5)
+                    )
+                    .focused($focused)
+                HStack {
+                    Spacer()
+                    Button("Cancel") { cancel() }
+                        .buttonStyle(.borderless)
+                        .font(.system(size: 11))
+                        .foregroundStyle(c.muted)
+                    Button("Send") { commit() }
+                        .buttonStyle(.borderless)
+                        .font(.system(size: 11, weight: .medium))
+                        .foregroundStyle(c.accent)
+                        .disabled(draft.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty)
+                }
+            } else {
+                Button {
+                    isComposing = true
+                    DispatchQueue.main.asyncAfter(deadline: .now() + 0.05) {
+                        focused = true
+                    }
+                } label: {
+                    HStack(spacing: 4) {
+                        Image(systemName: "arrowshape.turn.up.left")
+                        Text("Reply")
+                    }
+                    .font(.system(size: 11, weight: .medium))
+                    .foregroundStyle(c.accent)
+                }
+                .buttonStyle(.plain)
+            }
+        }
+        .onChange(of: focused) { _, isFocused in
+            if isFocused { installReturnMonitor() } else { removeReturnMonitor() }
+        }
+        .onDisappear { removeReturnMonitor() }
+    }
+
+    private func commit() {
+        let trimmed = draft.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !trimmed.isEmpty, let url = store.fileURL else { cancel(); return }
         store.appendThreadMessage(
             forPath: url.path,
-            annotationID: annotation.id,
+            annotationID: annotationID,
             author: "user",
             text: trimmed
         )
-        replyDraft = ""
-        cancelReply()
+        draft = ""
+        cancel()
     }
 
-    private func cancelReply() {
-        isReplying = false
-        replyFocused = false
-        replyDraft = ""
-    }
-
-    /// Local keyDown monitor. SwiftUI's TextEditor wraps an NSTextView
-    /// that insists on inserting a newline for Return; the monitor sees
-    /// the event first and can swallow it when no Shift is held,
-    /// routing instead to commit. Shift+Return falls through to the
-    /// TextEditor's default newline insertion. One monitor serves both
-    /// fields; the closure dispatches based on which @FocusState is
-    /// currently true at the time of the press.
-    private func syncReturnMonitor() {
-        if noteFocused || replyFocused {
-            installReturnMonitor()
-        } else {
-            removeReturnMonitor()
-        }
+    private func cancel() {
+        isComposing = false
+        focused = false
+        draft = ""
     }
 
     private func installReturnMonitor() {
@@ -617,9 +648,8 @@ struct AnnotationCard: View {
             guard isReturn, !event.modifierFlags.contains(.shift) else {
                 return event
             }
-            if replyFocused { commitReply(); return nil }
-            if noteFocused { commitNote(); return nil }
-            return event
+            commit()
+            return nil
         }
     }
 

--- a/Sources/mindle/ContentView.swift
+++ b/Sources/mindle/ContentView.swift
@@ -356,11 +356,15 @@ struct AnnotationsSidebar: View {
                     .onChange(of: store.focusedAnnotation) { _, newID in
                         // ⌘⇧N appends a new annotation to the array; on
                         // long files the new card lands below the
-                        // fold. Auto-scroll keeps the user's attention
-                        // anchored to the thing they just created.
+                        // fold. LazyVStack only renders rows on
+                        // appear, so scrollTo right now would be a
+                        // no-op for a brand-new id. Defer one runloop
+                        // pass so SwiftUI has materialized the row.
                         guard let id = newID else { return }
-                        withAnimation(.easeInOut(duration: 0.2)) {
-                            proxy.scrollTo(id, anchor: .center)
+                        DispatchQueue.main.asyncAfter(deadline: .now() + 0.08) {
+                            withAnimation(.easeInOut(duration: 0.2)) {
+                                proxy.scrollTo(id, anchor: .center)
+                            }
                         }
                     }
                 }

--- a/Sources/mindle/ContentView.swift
+++ b/Sources/mindle/ContentView.swift
@@ -583,7 +583,7 @@ struct AnnotationCard: View {
             forPath: url.path,
             annotationID: annotation.id,
             author: "user",
-            text: replyDraft
+            text: trimmed
         )
         replyDraft = ""
         cancelReply()

--- a/Sources/mindle/ContentView.swift
+++ b/Sources/mindle/ContentView.swift
@@ -344,7 +344,12 @@ struct AnnotationsSidebar: View {
             } else {
                 ScrollViewReader { proxy in
                     ScrollView {
-                        LazyVStack(alignment: .leading, spacing: 10) {
+                        // Eager VStack (not LazyVStack) because
+                        // scrollTo doesn't work for not-yet-realized
+                        // lazy rows, and annotation counts in a single
+                        // doc are bounded enough that eager rendering
+                        // is fine.
+                        VStack(alignment: .leading, spacing: 10) {
                             ForEach(store.annotations) { ann in
                                 AnnotationCard(annotation: ann)
                                     .id(ann.id)
@@ -354,12 +359,11 @@ struct AnnotationsSidebar: View {
                         .padding(.vertical, 12)
                     }
                     .onChange(of: store.focusedAnnotation) { _, newID in
-                        // ⌘⇧N appends a new annotation to the array; on
-                        // long files the new card lands below the
-                        // fold. LazyVStack only renders rows on
-                        // appear, so scrollTo right now would be a
-                        // no-op for a brand-new id. Defer one runloop
-                        // pass so SwiftUI has materialized the row.
+                        // ⌘⇧N appends a new annotation to the array;
+                        // on long files the new card lands below the
+                        // fold. Defer one runloop pass so the new row
+                        // is laid out before we ask the proxy to
+                        // scroll to it.
                         guard let id = newID else { return }
                         DispatchQueue.main.asyncAfter(deadline: .now() + 0.08) {
                             withAnimation(.easeInOut(duration: 0.2)) {

--- a/Sources/mindle/ContentView.swift
+++ b/Sources/mindle/ContentView.swift
@@ -342,14 +342,27 @@ struct AnnotationsSidebar: View {
                 }
                 .frame(maxWidth: .infinity, maxHeight: .infinity)
             } else {
-                ScrollView {
-                    LazyVStack(alignment: .leading, spacing: 10) {
-                        ForEach(store.annotations) { ann in
-                            AnnotationCard(annotation: ann)
+                ScrollViewReader { proxy in
+                    ScrollView {
+                        LazyVStack(alignment: .leading, spacing: 10) {
+                            ForEach(store.annotations) { ann in
+                                AnnotationCard(annotation: ann)
+                                    .id(ann.id)
+                            }
+                        }
+                        .padding(.horizontal, 12)
+                        .padding(.vertical, 12)
+                    }
+                    .onChange(of: store.focusedAnnotation) { _, newID in
+                        // ⌘⇧N appends a new annotation to the array; on
+                        // long files the new card lands below the
+                        // fold. Auto-scroll keeps the user's attention
+                        // anchored to the thing they just created.
+                        guard let id = newID else { return }
+                        withAnimation(.easeInOut(duration: 0.2)) {
+                            proxy.scrollTo(id, anchor: .center)
                         }
                     }
-                    .padding(.horizontal, 12)
-                    .padding(.vertical, 12)
                 }
             }
         }
@@ -568,25 +581,26 @@ struct AnnotationReplyBox: View {
     @EnvironmentObject var store: DocumentStore
     @State private var draft: String = ""
     @State private var isComposing: Bool = false
-    @FocusState private var focused: Bool
-    @State private var returnKeyMonitor: Any? = nil
+    @State private var focused: Bool = false
 
     var body: some View {
         let c = store.theme.colors
         VStack(alignment: .leading, spacing: 6) {
             if isComposing {
-                TextEditor(text: $draft)
-                    .font(.system(size: 12, design: .serif))
-                    .foregroundStyle(c.text)
-                    .scrollContentBackground(.hidden)
-                    .background(c.background.opacity(0.5))
-                    .frame(minHeight: 48, maxHeight: 120)
-                    .padding(6)
-                    .overlay(
-                        RoundedRectangle(cornerRadius: 5)
-                            .stroke(c.accent.opacity(0.45), lineWidth: 0.5)
-                    )
-                    .focused($focused)
+                FocusStableTextEditor(
+                    text: $draft,
+                    isFocused: $focused,
+                    font: Self.editorFont,
+                    textColor: NSColor(c.text),
+                    onCommit: commit
+                )
+                .frame(minHeight: 48, maxHeight: 120)
+                .padding(6)
+                .background(c.background.opacity(0.5))
+                .overlay(
+                    RoundedRectangle(cornerRadius: 5)
+                        .stroke(c.accent.opacity(0.45), lineWidth: 0.5)
+                )
                 HStack {
                     Spacer()
                     Button("Cancel") { cancel() }
@@ -602,6 +616,10 @@ struct AnnotationReplyBox: View {
             } else {
                 Button {
                     isComposing = true
+                    // Defer focus by one runloop pass so the
+                    // NSViewRepresentable's makeNSView has installed
+                    // the text view before we ask the window to focus
+                    // it.
                     DispatchQueue.main.asyncAfter(deadline: .now() + 0.05) {
                         focused = true
                     }
@@ -616,11 +634,16 @@ struct AnnotationReplyBox: View {
                 .buttonStyle(.plain)
             }
         }
-        .onChange(of: focused) { _, isFocused in
-            if isFocused { installReturnMonitor() } else { removeReturnMonitor() }
-        }
-        .onDisappear { removeReturnMonitor() }
     }
+
+    private static let editorFont: NSFont = {
+        let size: CGFloat = 12
+        if let descriptor = NSFont.systemFont(ofSize: size).fontDescriptor.withDesign(.serif),
+           let font = NSFont(descriptor: descriptor, size: size) {
+            return font
+        }
+        return NSFont.systemFont(ofSize: size)
+    }()
 
     private func commit() {
         let trimmed = draft.trimmingCharacters(in: .whitespacesAndNewlines)
@@ -639,25 +662,6 @@ struct AnnotationReplyBox: View {
         isComposing = false
         focused = false
         draft = ""
-    }
-
-    private func installReturnMonitor() {
-        guard returnKeyMonitor == nil else { return }
-        returnKeyMonitor = NSEvent.addLocalMonitorForEvents(matching: .keyDown) { event in
-            let isReturn = event.keyCode == 36 || event.keyCode == 76
-            guard isReturn, !event.modifierFlags.contains(.shift) else {
-                return event
-            }
-            commit()
-            return nil
-        }
-    }
-
-    private func removeReturnMonitor() {
-        if let m = returnKeyMonitor {
-            NSEvent.removeMonitor(m)
-            returnKeyMonitor = nil
-        }
     }
 }
 

--- a/Sources/mindle/DocumentStore.swift
+++ b/Sources/mindle/DocumentStore.swift
@@ -98,7 +98,24 @@ final class DocumentStore: ObservableObject {
     private var selectionSuffix: String = ""
 
     @Published var focusedAnnotation: UUID? = nil
-    @Published var editingAnnotationID: UUID? = nil
+    /// When the user creates an annotation via ⌘⇧N, the annotation appears
+    /// with an empty note and the editor opens. Each transition of
+    /// editingAnnotationID *away* from a value commits any pending
+    /// annotation: the `created` event fires here, not at append time,
+    /// so the watch loop sees the finished note instead of an empty
+    /// shell. (Highlights via ⌘⇧H are complete on creation and emit
+    /// immediately — they don't go through this path.)
+    @Published var editingAnnotationID: UUID? = nil {
+        didSet {
+            if let prev = oldValue, prev != editingAnnotationID {
+                commitPendingAnnotation(id: prev)
+            }
+        }
+    }
+    /// Set of annotation ids that were created via the note-editor path
+    /// and haven't surfaced as `created` events yet. They commit when
+    /// editing moves off them.
+    private var pendingCommitAnnotations: Set<UUID> = []
 
     // Bumped to trigger a PDF export in the WKWebView coordinator.
     @Published var pdfExportRequestedAt: Date? = nil
@@ -401,19 +418,33 @@ final class DocumentStore: ObservableObject {
                 note: ""
             )
             annotations.append(ann)
+            // Defer the `created` event until the user finishes typing
+            // the note — see editingAnnotationID's didSet. Emitting now
+            // would race with the typing: the watch loop would wake on
+            // an empty note before the user got past their first word.
+            pendingCommitAnnotations.insert(ann.id)
             editingAnnotationID = ann.id
             focusedAnnotation = ann.id
-            if let url = fileURL {
-                AnnotationEventLog.shared.append(
-                    kind: .created,
-                    path: url.path,
-                    annotationID: ann.id,
-                    annotation: ann,
-                    clientID: nil
-                )
-            }
             saveSidecar()
         }
+    }
+
+    /// Fire the deferred `created` event for an annotation that was
+    /// opened via the note-editor path, now that the user has finished
+    /// editing it. Called automatically when editingAnnotationID moves
+    /// off this annotation (Done click, Return commit, focusing a
+    /// different annotation, window/tab change).
+    private func commitPendingAnnotation(id: UUID) {
+        guard pendingCommitAnnotations.remove(id) != nil else { return }
+        guard let url = fileURL,
+              let ann = annotations.first(where: { $0.id == id }) else { return }
+        AnnotationEventLog.shared.append(
+            kind: .created,
+            path: url.path,
+            annotationID: ann.id,
+            annotation: ann,
+            clientID: nil
+        )
     }
 
     func updateNote(id: UUID, note: String) {
@@ -423,6 +454,11 @@ final class DocumentStore: ObservableObject {
     }
 
     func delete(id: UUID) {
+        // If the annotation never surfaced a `created` event (still in
+        // the note-editor pending state), drop it from the pending set
+        // so commitPendingAnnotation can't fire on a later
+        // editingAnnotationID transition.
+        pendingCommitAnnotations.remove(id)
         guard let url = fileURL else {
             annotations.removeAll { $0.id == id }
             saveSidecar()

--- a/Sources/mindle/DocumentStore.swift
+++ b/Sources/mindle/DocumentStore.swift
@@ -350,18 +350,37 @@ final class DocumentStore: ObservableObject {
 
     func highlightSelection() {
         guard hasSelection else { NSSound.beep(); return }
-        // Toggle off if an annotation already exists with identical text+context
         if let i = annotations.firstIndex(where: {
             $0.text == selectionText && $0.prefix == selectionPrefix && $0.suffix == selectionSuffix
         }) {
+            let removed = annotations[i]
             annotations.remove(at: i)
+            if let url = fileURL {
+                AnnotationEventLog.shared.append(
+                    kind: .deleted,
+                    path: url.path,
+                    annotationID: removed.id,
+                    annotation: nil,
+                    clientID: nil
+                )
+            }
         } else {
-            annotations.append(Annotation(
+            let ann = Annotation(
                 text: selectionText,
                 prefix: selectionPrefix,
                 suffix: selectionSuffix,
                 note: ""
-            ))
+            )
+            annotations.append(ann)
+            if let url = fileURL {
+                AnnotationEventLog.shared.append(
+                    kind: .created,
+                    path: url.path,
+                    annotationID: ann.id,
+                    annotation: ann,
+                    clientID: nil
+                )
+            }
         }
         saveSidecar()
     }
@@ -384,6 +403,15 @@ final class DocumentStore: ObservableObject {
             annotations.append(ann)
             editingAnnotationID = ann.id
             focusedAnnotation = ann.id
+            if let url = fileURL {
+                AnnotationEventLog.shared.append(
+                    kind: .created,
+                    path: url.path,
+                    annotationID: ann.id,
+                    annotation: ann,
+                    clientID: nil
+                )
+            }
             saveSidecar()
         }
     }
@@ -395,7 +423,22 @@ final class DocumentStore: ObservableObject {
     }
 
     func delete(id: UUID) {
+        guard let url = fileURL else {
+            annotations.removeAll { $0.id == id }
+            saveSidecar()
+            return
+        }
+        let removed = annotations.first(where: { $0.id == id })
         annotations.removeAll { $0.id == id }
+        if removed != nil {
+            AnnotationEventLog.shared.append(
+                kind: .deleted,
+                path: url.path,
+                annotationID: id,
+                annotation: nil,
+                clientID: nil
+            )
+        }
         saveSidecar()
     }
 
@@ -423,7 +466,8 @@ final class DocumentStore: ObservableObject {
         forPath path: String,
         annotationID: UUID,
         author: String,
-        text: String
+        text: String,
+        clientID: String? = nil
     ) -> Bool {
         let message = AnnotationMessage(author: author, text: text)
         if let active = activeTabID,
@@ -436,6 +480,14 @@ final class DocumentStore: ObservableObject {
             thread.append(message)
             annotations[j].thread = thread
             saveSidecar()
+            AnnotationEventLog.shared.append(
+                kind: .threadReply,
+                path: path,
+                annotationID: annotationID,
+                annotation: annotations[j],
+                messageID: message.id,
+                clientID: clientID
+            )
             return true
         }
         if let i = tabs.firstIndex(where: { $0.fileURL.path == path }) {
@@ -446,6 +498,14 @@ final class DocumentStore: ObservableObject {
             thread.append(message)
             tabs[i].annotations[j].thread = thread
             saveSidecar(forTab: tabs[i])
+            AnnotationEventLog.shared.append(
+                kind: .threadReply,
+                path: path,
+                annotationID: annotationID,
+                annotation: tabs[i].annotations[j],
+                messageID: message.id,
+                clientID: clientID
+            )
             return true
         }
         return false
@@ -460,7 +520,8 @@ final class DocumentStore: ObservableObject {
         text: String,
         prefix: String,
         suffix: String,
-        note: String
+        note: String,
+        clientID: String? = nil
     ) -> UUID? {
         let ann = Annotation(
             text: text,
@@ -476,11 +537,25 @@ final class DocumentStore: ObservableObject {
             annotations.append(ann)
             showAnnotations = true
             saveSidecar()
+            AnnotationEventLog.shared.append(
+                kind: .created,
+                path: path,
+                annotationID: ann.id,
+                annotation: ann,
+                clientID: clientID
+            )
             return ann.id
         }
         if let i = tabs.firstIndex(where: { $0.fileURL.path == path }) {
             tabs[i].annotations.append(ann)
             saveSidecar(forTab: tabs[i])
+            AnnotationEventLog.shared.append(
+                kind: .created,
+                path: path,
+                annotationID: ann.id,
+                annotation: ann,
+                clientID: clientID
+            )
             return ann.id
         }
         return nil
@@ -492,7 +567,7 @@ final class DocumentStore: ObservableObject {
     /// summary is stashed in NSLog for now — Phase 3 surfaces it in the
     /// UI as a chip next to the corresponding diff chunk.
     @discardableResult
-    func removeAnnotation(forPath path: String, id: UUID, summary: String) -> Bool {
+    func removeAnnotation(forPath path: String, id: UUID, summary: String, clientID: String? = nil) -> Bool {
         NSLog("[mindle.mcp] clear_annotation path=%@ id=%@ summary=%@", path, id.uuidString, summary)
         if let active = activeTabID,
            let i = tabs.firstIndex(where: { $0.id == active }),
@@ -502,12 +577,26 @@ final class DocumentStore: ObservableObject {
             // saveSidecar() pulls from in-memory annotations of the
             // active tab, so this persists correctly.
             saveSidecar()
+            AnnotationEventLog.shared.append(
+                kind: .deleted,
+                path: path,
+                annotationID: id,
+                annotation: nil,
+                clientID: clientID
+            )
             return true
         }
         if let i = tabs.firstIndex(where: { $0.fileURL.path == path }) {
             guard tabs[i].annotations.contains(where: { $0.id == id }) else { return false }
             tabs[i].annotations.removeAll { $0.id == id }
             saveSidecar(forTab: tabs[i])
+            AnnotationEventLog.shared.append(
+                kind: .deleted,
+                path: path,
+                annotationID: id,
+                annotation: nil,
+                clientID: clientID
+            )
             return true
         }
         return false

--- a/Sources/mindle/FocusStableTextEditor.swift
+++ b/Sources/mindle/FocusStableTextEditor.swift
@@ -50,6 +50,18 @@ struct FocusStableTextEditor: NSViewRepresentable {
         textView.onCommit = { [weak coord = context.coordinator] in
             coord?.parent.onCommit()
         }
+        // When the user clicks anywhere else (another card, the
+        // article, the file browser), AppKit takes first responder
+        // away from this text view. Push that back into the binding
+        // so updateNSView doesn't try to re-grab focus on the next
+        // store change. Without this, isFocused stays stuck at true
+        // and any sibling re-render yanks the cursor back to this
+        // textbox.
+        textView.onResignFocus = { [weak coord = context.coordinator] in
+            DispatchQueue.main.async {
+                coord?.parent.isFocused = false
+            }
+        }
 
         let scrollView = NSScrollView()
         scrollView.documentView = textView
@@ -116,14 +128,15 @@ struct FocusStableTextEditor: NSViewRepresentable {
 /// newline (the multi-line case).
 final class CommittingTextView: NSTextView {
     var onCommit: (() -> Void)?
+    /// Fired when this text view loses first-responder status. The
+    /// SwiftUI binding for isFocused needs to reflect AppKit reality,
+    /// otherwise updateNSView keeps trying to re-grab focus.
+    var onResignFocus: (() -> Void)?
 
     override func keyDown(with event: NSEvent) {
         let isReturn = event.keyCode == 36 || event.keyCode == 76
         if isReturn {
             if event.modifierFlags.contains(.shift) {
-                // Force a real newline. AppKit's default for Shift+Return
-                // in some configurations is `insertLineBreak:` which
-                // inserts U+2028 — not what users expect.
                 insertText("\n", replacementRange: selectedRange())
                 return
             }
@@ -131,5 +144,13 @@ final class CommittingTextView: NSTextView {
             return
         }
         super.keyDown(with: event)
+    }
+
+    override func resignFirstResponder() -> Bool {
+        let didResign = super.resignFirstResponder()
+        if didResign {
+            onResignFocus?()
+        }
+        return didResign
     }
 }

--- a/Sources/mindle/FocusStableTextEditor.swift
+++ b/Sources/mindle/FocusStableTextEditor.swift
@@ -1,0 +1,135 @@
+import SwiftUI
+import AppKit
+
+/// A multi-line text editor backed directly by `NSTextView`. Unlike
+/// SwiftUI's `TextEditor`, this view owns its `NSTextView` instance for
+/// the lifetime of the SwiftUI view and does not relinquish first
+/// responder on parent re-renders.
+///
+/// Why this exists: the annotation sidebar's `ForEach(store.annotations)`
+/// re-renders every card any time any annotation mutates (because
+/// `@EnvironmentObject store` fires on any `@Published` change). With a
+/// stock `TextEditor` + `@FocusState`, those sibling-driven re-renders
+/// can drop first responder mid-keystroke — the user reports "Mac
+/// beeps as I type while the agent posts on another annotation." This
+/// view's `updateNSView` is idempotent at the AppKit level: it only
+/// pushes a change to the text view when state actually differs, and
+/// it never resigns first responder on its own.
+///
+/// Behavior:
+/// - Return commits via `onCommit`.
+/// - Shift+Return inserts a literal newline (the multi-line case).
+/// - Text changes flow back via the `text` binding.
+struct FocusStableTextEditor: NSViewRepresentable {
+    @Binding var text: String
+    /// One-way: when this transitions from false to true, we ask the
+    /// window to make our text view the first responder. We never
+    /// resign on our own — only the user clicking elsewhere or another
+    /// view explicitly stealing focus removes it.
+    @Binding var isFocused: Bool
+    let font: NSFont
+    let textColor: NSColor
+    let onCommit: () -> Void
+
+    func makeNSView(context: Context) -> NSScrollView {
+        let textView = CommittingTextView()
+        textView.delegate = context.coordinator
+        textView.isRichText = false
+        textView.isEditable = true
+        textView.isSelectable = true
+        textView.allowsUndo = true
+        textView.font = font
+        textView.textColor = textColor
+        textView.drawsBackground = false
+        textView.isVerticallyResizable = true
+        textView.isHorizontallyResizable = false
+        textView.autoresizingMask = [.width]
+        textView.textContainerInset = NSSize(width: 0, height: 2)
+        textView.textContainer?.widthTracksTextView = true
+        textView.textContainer?.lineFragmentPadding = 0
+        textView.onCommit = { [weak coord = context.coordinator] in
+            coord?.parent.onCommit()
+        }
+
+        let scrollView = NSScrollView()
+        scrollView.documentView = textView
+        scrollView.hasVerticalScroller = true
+        scrollView.hasHorizontalScroller = false
+        scrollView.drawsBackground = false
+        scrollView.borderType = .noBorder
+        scrollView.autohidesScrollers = true
+
+        context.coordinator.textView = textView
+        return scrollView
+    }
+
+    func updateNSView(_ scrollView: NSScrollView, context: Context) {
+        guard let textView = scrollView.documentView as? CommittingTextView else { return }
+        // Refresh the coordinator's closure-bearing parent so the latest
+        // onCommit captures the latest state.
+        context.coordinator.parent = self
+
+        // Only mutate the text view's contents if they actually differ.
+        // Setting `string` blows away selection and undo state, so
+        // skipping the no-op case is what keeps typing smooth across
+        // sibling re-renders.
+        if textView.string != text {
+            textView.string = text
+        }
+        if textView.font != font {
+            textView.font = font
+        }
+        if textView.textColor != textColor {
+            textView.textColor = textColor
+        }
+
+        // Push first responder only on the rising edge of isFocused.
+        // We never call resignFirstResponder ourselves — AppKit handles
+        // resignation via user action, and a spurious SwiftUI re-render
+        // setting isFocused=false momentarily must not yank focus.
+        if isFocused, let window = textView.window, window.firstResponder !== textView {
+            window.makeFirstResponder(textView)
+        }
+    }
+
+    func makeCoordinator() -> Coordinator {
+        Coordinator(parent: self)
+    }
+
+    final class Coordinator: NSObject, NSTextViewDelegate {
+        var parent: FocusStableTextEditor
+        weak var textView: NSTextView?
+
+        init(parent: FocusStableTextEditor) {
+            self.parent = parent
+        }
+
+        func textDidChange(_ notification: Notification) {
+            guard let tv = notification.object as? NSTextView else { return }
+            parent.text = tv.string
+        }
+    }
+}
+
+/// NSTextView subclass that routes bare Return through a commit
+/// closure instead of inserting a newline. Shift+Return inserts a real
+/// newline (the multi-line case).
+final class CommittingTextView: NSTextView {
+    var onCommit: (() -> Void)?
+
+    override func keyDown(with event: NSEvent) {
+        let isReturn = event.keyCode == 36 || event.keyCode == 76
+        if isReturn {
+            if event.modifierFlags.contains(.shift) {
+                // Force a real newline. AppKit's default for Shift+Return
+                // in some configurations is `insertLineBreak:` which
+                // inserts U+2028 — not what users expect.
+                insertText("\n", replacementRange: selectedRange())
+                return
+            }
+            onCommit?()
+            return
+        }
+        super.keyDown(with: event)
+    }
+}

--- a/Sources/mindle/MCPServer.swift
+++ b/Sources/mindle/MCPServer.swift
@@ -146,6 +146,7 @@ final class MCPServer {
     // MARK: - Op dispatch (hops to MainActor for app state)
 
     private static func dispatch(op: String, request: [String: Any]) async -> [String: Any] {
+        let clientID = request["client_id"] as? String
         switch op {
         case "list_open_files":
             let files = await MainActor.run { AppDelegate.shared?.allOpenFilePaths() ?? [] }
@@ -202,7 +203,11 @@ final class MCPServer {
             let normalized = URL(fileURLWithPath: path).standardizedFileURL.path
             let appended = await MainActor.run {
                 AppDelegate.shared?.appendThreadMessage(
-                    forPath: normalized, annotationID: id, author: "agent", text: text
+                    forPath: normalized,
+                    annotationID: id,
+                    author: "agent",
+                    text: text,
+                    clientID: clientID
                 ) ?? false
             }
             if appended {
@@ -229,7 +234,8 @@ final class MCPServer {
                     text: text,
                     prefix: prefix,
                     suffix: suffix,
-                    note: note
+                    note: note,
+                    clientID: clientID
                 )
             }
             if let id = newID {
@@ -248,7 +254,7 @@ final class MCPServer {
             let normalized = URL(fileURLWithPath: path).standardizedFileURL.path
             let removed = await MainActor.run {
                 AppDelegate.shared?.clearAnnotation(
-                    forPath: normalized, id: id, summary: summary
+                    forPath: normalized, id: id, summary: summary, clientID: clientID
                 ) ?? false
             }
             if removed {

--- a/Sources/mindle/MCPServer.swift
+++ b/Sources/mindle/MCPServer.swift
@@ -123,6 +123,12 @@ final class MCPServer {
                 // listen socket closed — exit the loop.
                 return
             }
+            // SO_NOSIGPIPE: when the helper disconnects mid-wait, the
+            // next write() to this fd would otherwise raise SIGPIPE and
+            // kill Mindle. With SO_NOSIGPIPE the write() returns -1 with
+            // errno=EPIPE instead, and writeAll handles it cleanly.
+            var noSigPipe: Int32 = 1
+            setsockopt(clientFD, SOL_SOCKET, SO_NOSIGPIPE, &noSigPipe, socklen_t(MemoryLayout<Int32>.size))
             Task.detached(priority: .utility) {
                 await Self.handleClient(fd: clientFD)
             }

--- a/Sources/mindle/MCPServer.swift
+++ b/Sources/mindle/MCPServer.swift
@@ -163,26 +163,7 @@ final class MCPServer {
                 }
                 let iso = ISO8601DateFormatter()
                 return anns.map { ann -> [String: Any] in
-                    var payload: [String: Any] = [
-                        "id": ann.id.uuidString,
-                        "text": ann.text,
-                        "prefix": ann.prefix,
-                        "suffix": ann.suffix,
-                        "note": ann.note,
-                        "author": ann.author ?? "user",
-                        "createdAt": iso.string(from: ann.createdAt)
-                    ]
-                    if let thread = ann.thread, !thread.isEmpty {
-                        payload["thread"] = thread.map { msg -> [String: Any] in
-                            [
-                                "id": msg.id.uuidString,
-                                "author": msg.author,
-                                "text": msg.text,
-                                "createdAt": iso.string(from: msg.createdAt)
-                            ]
-                        }
-                    }
-                    return payload
+                    encodeAnnotation(ann, iso: iso)
                 }
             }
             guard let annotations = result else {
@@ -262,6 +243,39 @@ final class MCPServer {
             }
             return ["ok": false, "error": "annotation not found (file may not be open or id is stale)"]
 
+        case "wait_for_annotation_event":
+            let rawTimeout = (request["timeout_seconds"] as? Double) ?? 60.0
+            let timeoutSeconds = max(5.0, min(300.0, rawTimeout))
+            let sinceID = request["since_event_id"] as? Int
+            let result = await AnnotationEventLog.shared.wait(
+                sinceID: sinceID,
+                timeoutSeconds: timeoutSeconds,
+                excludingClientID: clientID
+            )
+            let iso = ISO8601DateFormatter()
+            let payload: [[String: Any]] = result.events.map { ev in
+                var entry: [String: Any] = [
+                    "event_id": ev.id,
+                    "type": ev.kind.rawValue,
+                    "path": ev.path,
+                    "annotation_id": ev.annotationID.uuidString,
+                    "occurred_at": iso.string(from: ev.occurredAt)
+                ]
+                if let ann = ev.annotation {
+                    entry["annotation"] = encodeAnnotation(ann, iso: iso)
+                }
+                if let mid = ev.messageID {
+                    entry["message_id"] = mid.uuidString
+                }
+                return entry
+            }
+            return [
+                "ok": true,
+                "events": payload,
+                "last_event_id": result.lastEventID,
+                "gap": result.gap
+            ]
+
         default:
             return ["ok": false, "error": "unknown op: \(op)"]
         }
@@ -320,5 +334,31 @@ final class MCPServer {
             }
             return true
         }
+    }
+
+    private static func encodeAnnotation(
+        _ ann: Annotation,
+        iso: ISO8601DateFormatter
+    ) -> [String: Any] {
+        var payload: [String: Any] = [
+            "id": ann.id.uuidString,
+            "text": ann.text,
+            "prefix": ann.prefix,
+            "suffix": ann.suffix,
+            "note": ann.note,
+            "author": ann.author ?? "user",
+            "createdAt": iso.string(from: ann.createdAt)
+        ]
+        if let thread = ann.thread, !thread.isEmpty {
+            payload["thread"] = thread.map { msg -> [String: Any] in
+                [
+                    "id": msg.id.uuidString,
+                    "author": msg.author,
+                    "text": msg.text,
+                    "createdAt": iso.string(from: msg.createdAt)
+                ]
+            }
+        }
+        return payload
     }
 }

--- a/Sources/mindle/MindleApp.swift
+++ b/Sources/mindle/MindleApp.swift
@@ -77,11 +77,11 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
     /// the file open. Returns true on success. The summary captures the
     /// agent's description of what it did to address the annotation —
     /// stashed for now, surfaced in the UI in Phase 3.
-    func clearAnnotation(forPath path: String, id: UUID, summary: String) -> Bool {
+    func clearAnnotation(forPath path: String, id: UUID, summary: String, clientID: String?) -> Bool {
         registeredStores.removeAll { $0.store == nil }
         for ref in registeredStores {
             guard let store = ref.store else { continue }
-            if store.removeAnnotation(forPath: path, id: id, summary: summary) {
+            if store.removeAnnotation(forPath: path, id: id, summary: summary, clientID: clientID) {
                 return true
             }
         }
@@ -94,7 +94,8 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
         forPath path: String,
         annotationID: UUID,
         author: String,
-        text: String
+        text: String,
+        clientID: String?
     ) -> Bool {
         registeredStores.removeAll { $0.store == nil }
         for ref in registeredStores {
@@ -102,7 +103,8 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
                 forPath: path,
                 annotationID: annotationID,
                 author: author,
-                text: text
+                text: text,
+                clientID: clientID
             ) == true {
                 return true
             }
@@ -118,7 +120,8 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
         text: String,
         prefix: String,
         suffix: String,
-        note: String
+        note: String,
+        clientID: String?
     ) -> UUID? {
         registeredStores.removeAll { $0.store == nil }
         for ref in registeredStores {
@@ -127,7 +130,8 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
                 text: text,
                 prefix: prefix,
                 suffix: suffix,
-                note: note
+                note: note,
+                clientID: clientID
             ) {
                 return id
             }

--- a/docs/superpowers/plans/2026-05-11-ambient-mindle-collaboration.md
+++ b/docs/superpowers/plans/2026-05-11-ambient-mindle-collaboration.md
@@ -1,0 +1,1197 @@
+# Ambient Mindle Collaboration Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Add a long-poll MCP tool `wait_for_annotation_event` that lets an agent watch a user's Mindle annotations across all open files and react to user events (annotation created, thread reply, annotation deleted) in an ambient collaboration loop.
+
+**Architecture:** A new `AnnotationEventLog` (MainActor singleton, in-memory ring buffer of 256 events) sits next to `MCPServer`. `DocumentStore` mutations append events to the log, tagged with the originating `clientID` (UUID per MCP helper instance, nil for user UI actions). `MCPServer` adds a `wait_for_annotation_event` op that awaits the log with a timeout and filters out events whose `clientID` matches the calling client — so the agent never wakes on its own mutations.
+
+**Tech Stack:** Swift, MainActor isolation, `withCheckedContinuation` for waiter primitives, length-prefixed JSON over a Unix-domain socket. No new external dependencies. Verification is build + stdio smoke tests + manual UI eyeballing.
+
+**Spec reference:** `docs/superpowers/specs/2026-05-11-ambient-mindle-collaboration-design.md`
+
+---
+
+## File Structure
+
+**Create:**
+- `Sources/mindle/AnnotationEventLog.swift` — `AnnotationEvent` struct, `AnnotationEventLog` singleton with append/wait API.
+
+**Modify:**
+- `Sources/mindle/DocumentStore.swift` — append events on every annotation mutation (user UI path and MCP path), accept `clientID` through MCP-side mutations so events get tagged.
+- `Sources/mindle/MindleApp.swift` — `AppDelegate` aggregator helpers thread `clientID` through to `DocumentStore`.
+- `Sources/mindle/MCPServer.swift` — extract `client_id` from every request; pass through to mutations; new `wait_for_annotation_event` op.
+- `Sources/MindleMCP/main.swift` — generate one `clientID` at helper startup; include `client_id` in every JSON body; declare and dispatch the new `wait_for_annotation_event` tool.
+
+---
+
+## Task 1: Create AnnotationEventLog skeleton (no waiters yet)
+
+**Files:**
+- Create: `Sources/mindle/AnnotationEventLog.swift`
+
+- [ ] **Step 1: Create the file**
+
+Write `Sources/mindle/AnnotationEventLog.swift`:
+
+```swift
+import Foundation
+
+/// One entry in the cross-window event log. Mutations of any annotation
+/// (created, reply added to thread, deleted) become events. The agent
+/// pulls them through `MCPServer.wait_for_annotation_event` to drive
+/// an ambient collaboration loop.
+struct AnnotationEvent {
+    enum Kind: String {
+        case created
+        case threadReply = "thread_reply"
+        case deleted
+    }
+
+    let id: Int
+    let kind: Kind
+    let path: String
+    let annotationID: UUID
+    /// Full annotation payload for created/threadReply. nil for deleted —
+    /// the annotation no longer exists by the time consumers see it.
+    let annotation: Annotation?
+    /// For threadReply: the id of the new message. nil otherwise.
+    let messageID: UUID?
+    let occurredAt: Date
+    /// UUID of the MCP client whose mutation produced this event, or nil
+    /// for user UI actions. `wait_for_annotation_event` filters out
+    /// events whose clientID equals the caller's clientID — the agent
+    /// must not wake on its own writes.
+    let clientID: String?
+}
+
+/// MainActor-isolated event log. Ring-buffered to the last 256 events;
+/// older events drop and consumers that fall further behind receive a
+/// gap signal so they can rebaseline via get_annotations.
+@MainActor
+final class AnnotationEventLog {
+    static let shared = AnnotationEventLog()
+
+    private var events: [AnnotationEvent] = []
+    private var nextID: Int = 1
+    private let capacity: Int = 256
+
+    private init() {}
+
+    /// Append a new event. Caller supplies the payload (kind, path, etc.);
+    /// the log assigns the monotonic id and timestamp.
+    func append(
+        kind: AnnotationEvent.Kind,
+        path: String,
+        annotationID: UUID,
+        annotation: Annotation?,
+        messageID: UUID? = nil,
+        clientID: String?
+    ) {
+        let event = AnnotationEvent(
+            id: nextID,
+            kind: kind,
+            path: path,
+            annotationID: annotationID,
+            annotation: annotation,
+            messageID: messageID,
+            occurredAt: Date(),
+            clientID: clientID
+        )
+        nextID += 1
+        events.append(event)
+        if events.count > capacity {
+            events.removeFirst(events.count - capacity)
+        }
+    }
+
+    /// Read-only snapshot. Returns events with id > sinceID whose
+    /// clientID is not equal to `excludingClientID`. The caller uses
+    /// the result's `gap` to decide whether to rebaseline.
+    func snapshot(
+        sinceID: Int?,
+        excludingClientID: String?
+    ) -> (events: [AnnotationEvent], lastEventID: Int, gap: Bool) {
+        let lastID = (nextID - 1)
+        let oldestID = events.first?.id ?? 1
+        let effectiveSince = sinceID ?? lastID
+
+        let gap: Bool = {
+            if let since = sinceID, since < oldestID - 1 { return true }
+            return false
+        }()
+
+        let filtered = events.filter { ev in
+            ev.id > effectiveSince &&
+            ev.clientID != excludingClientID
+        }
+        return (filtered, lastID, gap)
+    }
+}
+```
+
+- [ ] **Step 2: Verify build**
+
+Run: `./build.sh 2>&1 | tail -5`
+Expected: `✓ Built build/Mindle.app`
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add Sources/mindle/AnnotationEventLog.swift
+git commit -m "Add AnnotationEventLog skeleton (append + snapshot, no waiters yet)"
+```
+
+---
+
+## Task 2: Append events on user-driven UI mutations
+
+**Files:**
+- Modify: `Sources/mindle/DocumentStore.swift`
+
+User UI paths emit events with `clientID: nil`. The four user mutation sites:
+- `highlightSelection()` — both add and remove branches
+- `addNoteToSelection()` — add-new-annotation branch only (focus-existing is not a mutation)
+- `delete(id:)` — single deletion
+- `updateNote(id:note:)` — explicitly **not** an event per spec; do nothing
+
+User thread replies come through `appendThreadMessage(forPath:annotationID:author:text:)`. That method is called from both UI (`AnnotationCard.commitReply` with `author: "user"`) and MCP (`comment_on_annotation` with `author: "agent"`). The agent path will pass a non-nil clientID in Task 3; for now we add the parameter and default it to nil.
+
+- [ ] **Step 1: Add clientID parameter to MCP-relevant mutation methods**
+
+In `Sources/mindle/DocumentStore.swift`, change the following method signatures to accept an optional `clientID` argument (default `nil` so existing UI call sites keep working unchanged):
+
+```swift
+func appendThreadMessage(
+    forPath path: String,
+    annotationID: UUID,
+    author: String,
+    text: String,
+    clientID: String? = nil
+) -> Bool {
+    // existing body
+}
+
+func createAgentAnnotation(
+    forPath path: String,
+    text: String,
+    prefix: String,
+    suffix: String,
+    note: String,
+    clientID: String? = nil
+) -> UUID? {
+    // existing body
+}
+
+@discardableResult
+func removeAnnotation(
+    forPath path: String,
+    id: UUID,
+    summary: String,
+    clientID: String? = nil
+) -> Bool {
+    // existing body
+}
+```
+
+- [ ] **Step 2: Append events inside each user mutation site**
+
+In `highlightSelection()`, the existing body has an add path and a toggle-off path. Append events on each:
+
+```swift
+func highlightSelection() {
+    guard hasSelection else { NSSound.beep(); return }
+    if let i = annotations.firstIndex(where: {
+        $0.text == selectionText && $0.prefix == selectionPrefix && $0.suffix == selectionSuffix
+    }) {
+        let removed = annotations[i]
+        annotations.remove(at: i)
+        if let url = fileURL {
+            AnnotationEventLog.shared.append(
+                kind: .deleted,
+                path: url.path,
+                annotationID: removed.id,
+                annotation: nil,
+                clientID: nil
+            )
+        }
+    } else {
+        let ann = Annotation(
+            text: selectionText,
+            prefix: selectionPrefix,
+            suffix: selectionSuffix,
+            note: ""
+        )
+        annotations.append(ann)
+        if let url = fileURL {
+            AnnotationEventLog.shared.append(
+                kind: .created,
+                path: url.path,
+                annotationID: ann.id,
+                annotation: ann,
+                clientID: nil
+            )
+        }
+    }
+    saveSidecar()
+}
+```
+
+In `addNoteToSelection()`, only the new-annotation branch emits:
+
+```swift
+func addNoteToSelection() {
+    guard hasSelection else { NSSound.beep(); return }
+    showAnnotations = true
+    if let existing = annotations.first(where: {
+        $0.text == selectionText && $0.prefix == selectionPrefix && $0.suffix == selectionSuffix
+    }) {
+        editingAnnotationID = existing.id
+        focusedAnnotation = existing.id
+    } else {
+        let ann = Annotation(
+            text: selectionText,
+            prefix: selectionPrefix,
+            suffix: selectionSuffix,
+            note: ""
+        )
+        annotations.append(ann)
+        editingAnnotationID = ann.id
+        focusedAnnotation = ann.id
+        if let url = fileURL {
+            AnnotationEventLog.shared.append(
+                kind: .created,
+                path: url.path,
+                annotationID: ann.id,
+                annotation: ann,
+                clientID: nil
+            )
+        }
+        saveSidecar()
+    }
+}
+```
+
+In `delete(id:)`:
+
+```swift
+func delete(id: UUID) {
+    guard let url = fileURL else {
+        annotations.removeAll { $0.id == id }
+        saveSidecar()
+        return
+    }
+    let removed = annotations.first(where: { $0.id == id })
+    annotations.removeAll { $0.id == id }
+    if removed != nil {
+        AnnotationEventLog.shared.append(
+            kind: .deleted,
+            path: url.path,
+            annotationID: id,
+            annotation: nil,
+            clientID: nil
+        )
+    }
+    saveSidecar()
+}
+```
+
+- [ ] **Step 3: Append thread-reply events inside `appendThreadMessage`**
+
+Update both branches (active-tab and inactive-tab) to append a `threadReply` event before returning true. After the existing mutation, before the `return true`:
+
+```swift
+let updatedAnnotation = /* the annotation after mutation — fetch via firstIndex */
+AnnotationEventLog.shared.append(
+    kind: .threadReply,
+    path: path,
+    annotationID: annotationID,
+    annotation: updatedAnnotation,
+    messageID: message.id,
+    clientID: clientID
+)
+```
+
+Full updated method body:
+
+```swift
+@discardableResult
+func appendThreadMessage(
+    forPath path: String,
+    annotationID: UUID,
+    author: String,
+    text: String,
+    clientID: String? = nil
+) -> Bool {
+    let message = AnnotationMessage(author: author, text: text)
+    if let active = activeTabID,
+       let i = tabs.firstIndex(where: { $0.id == active }),
+       tabs[i].fileURL.path == path {
+        guard let j = annotations.firstIndex(where: { $0.id == annotationID }) else {
+            return false
+        }
+        var thread = annotations[j].thread ?? []
+        thread.append(message)
+        annotations[j].thread = thread
+        saveSidecar()
+        AnnotationEventLog.shared.append(
+            kind: .threadReply,
+            path: path,
+            annotationID: annotationID,
+            annotation: annotations[j],
+            messageID: message.id,
+            clientID: clientID
+        )
+        return true
+    }
+    if let i = tabs.firstIndex(where: { $0.fileURL.path == path }) {
+        guard let j = tabs[i].annotations.firstIndex(where: { $0.id == annotationID }) else {
+            return false
+        }
+        var thread = tabs[i].annotations[j].thread ?? []
+        thread.append(message)
+        tabs[i].annotations[j].thread = thread
+        saveSidecar(forTab: tabs[i])
+        AnnotationEventLog.shared.append(
+            kind: .threadReply,
+            path: path,
+            annotationID: annotationID,
+            annotation: tabs[i].annotations[j],
+            messageID: message.id,
+            clientID: clientID
+        )
+        return true
+    }
+    return false
+}
+```
+
+- [ ] **Step 4: Append events inside `createAgentAnnotation` and `removeAnnotation`**
+
+For `createAgentAnnotation`, both branches append a `created` event before returning the id:
+
+```swift
+func createAgentAnnotation(
+    forPath path: String,
+    text: String,
+    prefix: String,
+    suffix: String,
+    note: String,
+    clientID: String? = nil
+) -> UUID? {
+    let ann = Annotation(
+        text: text,
+        prefix: prefix,
+        suffix: suffix,
+        note: note,
+        author: "agent",
+        thread: nil
+    )
+    if let active = activeTabID,
+       let i = tabs.firstIndex(where: { $0.id == active }),
+       tabs[i].fileURL.path == path {
+        annotations.append(ann)
+        showAnnotations = true
+        saveSidecar()
+        AnnotationEventLog.shared.append(
+            kind: .created,
+            path: path,
+            annotationID: ann.id,
+            annotation: ann,
+            clientID: clientID
+        )
+        return ann.id
+    }
+    if let i = tabs.firstIndex(where: { $0.fileURL.path == path }) {
+        tabs[i].annotations.append(ann)
+        saveSidecar(forTab: tabs[i])
+        AnnotationEventLog.shared.append(
+            kind: .created,
+            path: path,
+            annotationID: ann.id,
+            annotation: ann,
+            clientID: clientID
+        )
+        return ann.id
+    }
+    return nil
+}
+```
+
+For `removeAnnotation` (MCP `clear_annotation` path), both branches append a `deleted` event:
+
+```swift
+@discardableResult
+func removeAnnotation(
+    forPath path: String,
+    id: UUID,
+    summary: String,
+    clientID: String? = nil
+) -> Bool {
+    NSLog("[mindle.mcp] clear_annotation path=%@ id=%@ summary=%@", path, id.uuidString, summary)
+    if let active = activeTabID,
+       let i = tabs.firstIndex(where: { $0.id == active }),
+       tabs[i].fileURL.path == path {
+        guard annotations.contains(where: { $0.id == id }) else { return false }
+        annotations.removeAll { $0.id == id }
+        saveSidecar()
+        AnnotationEventLog.shared.append(
+            kind: .deleted,
+            path: path,
+            annotationID: id,
+            annotation: nil,
+            clientID: clientID
+        )
+        return true
+    }
+    if let i = tabs.firstIndex(where: { $0.fileURL.path == path }) {
+        guard tabs[i].annotations.contains(where: { $0.id == id }) else { return false }
+        tabs[i].annotations.removeAll { $0.id == id }
+        saveSidecar(forTab: tabs[i])
+        AnnotationEventLog.shared.append(
+            kind: .deleted,
+            path: path,
+            annotationID: id,
+            annotation: nil,
+            clientID: clientID
+        )
+        return true
+    }
+    return false
+}
+```
+
+- [ ] **Step 5: Verify build**
+
+Run: `./build.sh 2>&1 | tail -5`
+Expected: `✓ Built build/Mindle.app`
+
+- [ ] **Step 6: Manual sanity check via NSLog**
+
+Add a temporary NSLog at the top of `AnnotationEventLog.append`:
+
+```swift
+NSLog("[mindle.log] event kind=%@ path=%@ clientID=%@", kind.rawValue, path, clientID ?? "nil")
+```
+
+Install build:
+
+```bash
+osascript -e 'quit app "Mindle"'
+sleep 1
+rm -rf /Applications/Mindle.app
+cp -R /Users/neptune/workdir/mindle/build/Mindle.app /Applications/
+open /Applications/Mindle.app
+log stream --process Mindle --predicate 'composedMessage CONTAINS "mindle.log"' --info
+```
+
+In another terminal/shell session, open a file in Mindle, highlight a passage (⌘⇧H), then add a note (⌘⇧N). Expect to see two log lines with `kind=created path=...md clientID=nil`.
+
+Once verified, remove the temporary NSLog.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add Sources/mindle/DocumentStore.swift
+git commit -m "Append events to AnnotationEventLog on user annotation mutations"
+```
+
+---
+
+## Task 3: Thread clientID through AppDelegate aggregators and MCPServer mutations
+
+**Files:**
+- Modify: `Sources/mindle/MindleApp.swift`
+- Modify: `Sources/mindle/MCPServer.swift`
+
+- [ ] **Step 1: Update AppDelegate aggregator method signatures**
+
+In `Sources/mindle/MindleApp.swift`, every aggregator that mutates annotations on behalf of an agent grows a `clientID: String?` parameter and passes it to `DocumentStore`:
+
+```swift
+func clearAnnotation(forPath path: String, id: UUID, summary: String, clientID: String?) -> Bool {
+    registeredStores.removeAll { $0.store == nil }
+    for ref in registeredStores {
+        guard let store = ref.store else { continue }
+        if store.removeAnnotation(forPath: path, id: id, summary: summary, clientID: clientID) {
+            return true
+        }
+    }
+    return false
+}
+
+func appendThreadMessage(
+    forPath path: String,
+    annotationID: UUID,
+    author: String,
+    text: String,
+    clientID: String?
+) -> Bool {
+    registeredStores.removeAll { $0.store == nil }
+    for ref in registeredStores {
+        if ref.store?.appendThreadMessage(
+            forPath: path,
+            annotationID: annotationID,
+            author: author,
+            text: text,
+            clientID: clientID
+        ) == true {
+            return true
+        }
+    }
+    return false
+}
+
+func createAgentAnnotation(
+    forPath path: String,
+    text: String,
+    prefix: String,
+    suffix: String,
+    note: String,
+    clientID: String?
+) -> UUID? {
+    registeredStores.removeAll { $0.store == nil }
+    for ref in registeredStores {
+        if let id = ref.store?.createAgentAnnotation(
+            forPath: path,
+            text: text,
+            prefix: prefix,
+            suffix: suffix,
+            note: note,
+            clientID: clientID
+        ) {
+            return id
+        }
+    }
+    return nil
+}
+```
+
+- [ ] **Step 2: Extract client_id in MCPServer dispatch and pass it through**
+
+In `Sources/mindle/MCPServer.swift`, the `dispatch` function gains a top-of-body extraction:
+
+```swift
+private static func dispatch(op: String, request: [String: Any]) async -> [String: Any] {
+    let clientID = request["client_id"] as? String
+    switch op {
+    // ... cases below now use `clientID` where they call AppDelegate.shared aggregators
+    }
+}
+```
+
+Update the three mutating cases to pass `clientID`:
+
+```swift
+case "clear_annotation":
+    // ... existing validation ...
+    let removed = await MainActor.run {
+        AppDelegate.shared?.clearAnnotation(
+            forPath: normalized, id: id, summary: summary, clientID: clientID
+        ) ?? false
+    }
+    // ... rest unchanged ...
+
+case "comment_on_annotation":
+    // ... existing validation ...
+    let appended = await MainActor.run {
+        AppDelegate.shared?.appendThreadMessage(
+            forPath: normalized,
+            annotationID: id,
+            author: "agent",
+            text: text,
+            clientID: clientID
+        ) ?? false
+    }
+    // ... rest unchanged ...
+
+case "create_annotation":
+    // ... existing validation ...
+    let newID = await MainActor.run {
+        AppDelegate.shared?.createAgentAnnotation(
+            forPath: normalized,
+            text: text,
+            prefix: prefix,
+            suffix: suffix,
+            note: note,
+            clientID: clientID
+        )
+    }
+    // ... rest unchanged ...
+```
+
+- [ ] **Step 3: Verify build**
+
+Run: `./build.sh 2>&1 | tail -5`
+Expected: `✓ Built build/Mindle.app`
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add Sources/mindle/MindleApp.swift Sources/mindle/MCPServer.swift
+git commit -m "Thread clientID through MCP mutation dispatch"
+```
+
+---
+
+## Task 4: Helper generates clientID and stamps every request
+
+**Files:**
+- Modify: `Sources/MindleMCP/main.swift`
+
+- [ ] **Step 1: Generate clientID at helper startup**
+
+In `Sources/MindleMCP/main.swift`, add a static property on the `MindleMCP` struct:
+
+```swift
+/// Stable UUID for the lifetime of this helper process. Threaded into
+/// every Mindle request so Mindle can tag mutations and filter them
+/// back out of wait_for_annotation_event responses for the same client.
+private static let clientID: String = UUID().uuidString
+```
+
+- [ ] **Step 2: Add client_id to every callMindle body**
+
+Modify `callMindle` so it stamps the client_id into the request before serialization:
+
+```swift
+private static func callMindle(
+    op: String,
+    body: [String: Any],
+    format: ([String: Any]) -> [String: Any]
+) -> [String: Any] {
+    // ... existing socket setup ...
+
+    var request = body
+    request["op"] = op
+    request["client_id"] = clientID
+    guard let data = try? JSONSerialization.data(withJSONObject: request) else {
+        return errorContent("could not encode request")
+    }
+    // ... rest unchanged ...
+}
+```
+
+- [ ] **Step 3: Verify build**
+
+Run: `./build.sh 2>&1 | tail -5`
+Expected: `✓ Built build/Mindle.app`
+
+- [ ] **Step 4: Smoke test that existing tools still work**
+
+```bash
+printf '%s\n' \
+  '{"jsonrpc":"2.0","id":1,"method":"tools/call","params":{"name":"list_open_files","arguments":{}}}' \
+  | /Users/neptune/workdir/mindle/build/Mindle.app/Contents/MacOS/mindle-mcp \
+  | head -3
+```
+
+Expected: a JSON-RPC response with `content` containing either the open file list or "No files are currently open" — anything that's not an `error`.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add Sources/MindleMCP/main.swift
+git commit -m "mindle-mcp: generate clientID per helper, stamp every request"
+```
+
+---
+
+## Task 5: Add wait() to AnnotationEventLog with timeout
+
+**Files:**
+- Modify: `Sources/mindle/AnnotationEventLog.swift`
+
+- [ ] **Step 1: Add a Waiter type and a wait() method**
+
+Append to `AnnotationEventLog`:
+
+```swift
+/// One pending wait_for_annotation_event call. The continuation is
+/// resumed exactly once — either by `signalWaiters()` when an event
+/// arrives that the waiter cares about, or by the timeout task when
+/// `timeoutSeconds` elapses.
+private final class Waiter {
+    let sinceID: Int?
+    let excludingClientID: String?
+    let continuation: CheckedContinuation<(events: [AnnotationEvent], lastEventID: Int, gap: Bool), Never>
+    var resumed: Bool = false
+
+    init(
+        sinceID: Int?,
+        excludingClientID: String?,
+        continuation: CheckedContinuation<(events: [AnnotationEvent], lastEventID: Int, gap: Bool), Never>
+    ) {
+        self.sinceID = sinceID
+        self.excludingClientID = excludingClientID
+        self.continuation = continuation
+    }
+}
+
+private var waiters: [Waiter] = []
+```
+
+Add the wait method:
+
+```swift
+/// Long-poll for the next event matching the filter. Returns the
+/// current snapshot immediately if it already contains events the
+/// caller hasn't seen; otherwise blocks for up to timeoutSeconds.
+///
+/// Note: `sinceID == nil` means "from now" — only events appended
+/// AFTER this call returns. This matches the spec's "agent calls
+/// get_annotations to baseline, then watches for new events."
+func wait(
+    sinceID: Int?,
+    timeoutSeconds: Double,
+    excludingClientID: String?
+) async -> (events: [AnnotationEvent], lastEventID: Int, gap: Bool) {
+    // Pending events already in the log?
+    let snap = snapshot(sinceID: sinceID, excludingClientID: excludingClientID)
+    if !snap.events.isEmpty || snap.gap {
+        return snap
+    }
+
+    // Otherwise, register a waiter and race against the timeout.
+    return await withCheckedContinuation { continuation in
+        let waiter = Waiter(
+            sinceID: sinceID,
+            excludingClientID: excludingClientID,
+            continuation: continuation
+        )
+        waiters.append(waiter)
+
+        Task { @MainActor in
+            try? await Task.sleep(nanoseconds: UInt64(timeoutSeconds * 1_000_000_000))
+            self.resume(waiter, withEmpty: true)
+        }
+    }
+}
+
+/// Resolve a single waiter exactly once. Removes it from the queue.
+private func resume(
+    _ waiter: Waiter,
+    withEmpty: Bool
+) {
+    guard !waiter.resumed else { return }
+    waiter.resumed = true
+    if let idx = waiters.firstIndex(where: { $0 === waiter }) {
+        waiters.remove(at: idx)
+    }
+    if withEmpty {
+        waiter.continuation.resume(
+            returning: ([], nextID - 1, false)
+        )
+    } else {
+        let snap = snapshot(
+            sinceID: waiter.sinceID,
+            excludingClientID: waiter.excludingClientID
+        )
+        waiter.continuation.resume(returning: snap)
+    }
+}
+```
+
+Modify `append` to signal waiters after the event lands:
+
+```swift
+func append(
+    kind: AnnotationEvent.Kind,
+    path: String,
+    annotationID: UUID,
+    annotation: Annotation?,
+    messageID: UUID? = nil,
+    clientID: String?
+) {
+    // ... existing body that appends the event and trims to capacity ...
+
+    signalWaiters()
+}
+
+private func signalWaiters() {
+    // Iterate a snapshot of waiters so resume() can mutate the array.
+    let pending = waiters
+    for waiter in pending {
+        let snap = snapshot(
+            sinceID: waiter.sinceID,
+            excludingClientID: waiter.excludingClientID
+        )
+        if !snap.events.isEmpty || snap.gap {
+            resume(waiter, withEmpty: false)
+        }
+    }
+}
+```
+
+- [ ] **Step 2: Verify build**
+
+Run: `./build.sh 2>&1 | tail -5`
+Expected: `✓ Built build/Mindle.app`
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add Sources/mindle/AnnotationEventLog.swift
+git commit -m "AnnotationEventLog: long-poll wait() with timeout + waiter signaling"
+```
+
+---
+
+## Task 6: MCPServer wait_for_annotation_event op
+
+**Files:**
+- Modify: `Sources/mindle/MCPServer.swift`
+
+- [ ] **Step 1: Add the new op to dispatch**
+
+In `Sources/mindle/MCPServer.swift`, add a new case before `default`:
+
+```swift
+case "wait_for_annotation_event":
+    let rawTimeout = (request["timeout_seconds"] as? Double) ?? 60.0
+    let timeoutSeconds = max(5.0, min(300.0, rawTimeout))
+    let sinceID = request["since_event_id"] as? Int
+    let result = await AnnotationEventLog.shared.wait(
+        sinceID: sinceID,
+        timeoutSeconds: timeoutSeconds,
+        excludingClientID: clientID
+    )
+    let iso = ISO8601DateFormatter()
+    let payload: [[String: Any]] = result.events.map { ev in
+        var entry: [String: Any] = [
+            "event_id": ev.id,
+            "type": ev.kind.rawValue,
+            "path": ev.path,
+            "annotation_id": ev.annotationID.uuidString,
+            "occurred_at": iso.string(from: ev.occurredAt)
+        ]
+        if let ann = ev.annotation {
+            entry["annotation"] = encodeAnnotation(ann, iso: iso)
+        }
+        if let mid = ev.messageID {
+            entry["message_id"] = mid.uuidString
+        }
+        return entry
+    }
+    return [
+        "ok": true,
+        "events": payload,
+        "last_event_id": result.lastEventID,
+        "gap": result.gap
+    ]
+```
+
+Add a helper at the bottom of `MCPServer` (next to `dispatch`):
+
+```swift
+private static func encodeAnnotation(
+    _ ann: Annotation,
+    iso: ISO8601DateFormatter
+) -> [String: Any] {
+    var payload: [String: Any] = [
+        "id": ann.id.uuidString,
+        "text": ann.text,
+        "prefix": ann.prefix,
+        "suffix": ann.suffix,
+        "note": ann.note,
+        "author": ann.author ?? "user",
+        "createdAt": iso.string(from: ann.createdAt)
+    ]
+    if let thread = ann.thread, !thread.isEmpty {
+        payload["thread"] = thread.map { msg -> [String: Any] in
+            [
+                "id": msg.id.uuidString,
+                "author": msg.author,
+                "text": msg.text,
+                "createdAt": iso.string(from: msg.createdAt)
+            ]
+        }
+    }
+    return payload
+}
+```
+
+Refactor the existing `get_annotations` case to use `encodeAnnotation` so the wire format stays consistent between snapshots and events. Replace the inline annotation-to-dict block in `get_annotations` with:
+
+```swift
+return anns.map { ann -> [String: Any] in
+    encodeAnnotation(ann, iso: iso)
+}
+```
+
+- [ ] **Step 2: Verify build**
+
+Run: `./build.sh 2>&1 | tail -5`
+Expected: `✓ Built build/Mindle.app`
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add Sources/mindle/MCPServer.swift
+git commit -m "MCPServer: wait_for_annotation_event op + shared annotation encoder"
+```
+
+---
+
+## Task 7: Helper exposes wait_for_annotation_event as MCP tool
+
+**Files:**
+- Modify: `Sources/MindleMCP/main.swift`
+
+- [ ] **Step 1: Add the tool definition**
+
+In `Sources/MindleMCP/main.swift`, inside `toolDefinitions()`, append a new entry to the array:
+
+```swift
+[
+    "name": "wait_for_annotation_event",
+    "description": "Long-poll for the next user annotation event in Mindle. Use this to run an ambient collaboration loop: the user annotates a file in Mindle, you wake up here with the event payload, address it (read context, edit the file, comment_on_annotation or clear_annotation as appropriate), then call wait_for_annotation_event again. Wakeup events are: a new annotation, a user reply in an existing thread, an annotation deletion. Your own mutations (clear_annotation, comment_on_annotation, create_annotation) never wake you. Before starting the loop, call list_open_files and get_annotations on each open file so you have baseline context. The result includes 'events' (possibly empty if the timeout elapsed — call again), 'last_event_id' (pass back as since_event_id), and 'gap' (true if events were dropped between calls — rebaseline with get_annotations).",
+    "inputSchema": [
+        "type": "object",
+        "properties": [
+            "timeout_seconds": [
+                "type": "number",
+                "description": "How long to wait for an event before returning empty. Server clamps to [5, 300]. Default 60.",
+                "default": 60
+            ],
+            "since_event_id": [
+                "type": "integer",
+                "description": "The last_event_id from your previous wait_for_annotation_event call. Pass null on the first call to wait for events from now forward."
+            ]
+        ],
+        "additionalProperties": false
+    ]
+]
+```
+
+- [ ] **Step 2: Add dispatch in handleToolCall**
+
+In `Sources/MindleMCP/main.swift`, `handleToolCall`, add a new case before `default`:
+
+```swift
+case "wait_for_annotation_event":
+    var body: [String: Any] = [:]
+    if let t = arguments["timeout_seconds"] {
+        body["timeout_seconds"] = t
+    }
+    if let s = arguments["since_event_id"] {
+        body["since_event_id"] = s
+    }
+    return callMindle(op: "wait_for_annotation_event", body: body) { resp in
+        guard let events = resp["events"] as? [[String: Any]] else {
+            return errorContent("malformed response from Mindle")
+        }
+        let lastEventID = (resp["last_event_id"] as? Int) ?? 0
+        let gap = (resp["gap"] as? Bool) ?? false
+        if events.isEmpty {
+            // Empty timeout return — give the agent something to scan
+            // so it knows the call returned cleanly and can loop.
+            let gapNote = gap ? " (gap=true; rebaseline via get_annotations)" : ""
+            return textContent("No new events. last_event_id=\(lastEventID)\(gapNote)")
+        }
+        var lines: [String] = ["Events (last_event_id=\(lastEventID), gap=\(gap)):"]
+        for ev in events {
+            let id = (ev["event_id"] as? Int) ?? 0
+            let kind = (ev["type"] as? String) ?? "?"
+            let path = (ev["path"] as? String) ?? "?"
+            let annID = (ev["annotation_id"] as? String) ?? "?"
+            lines.append("- [event \(id)] \(kind) on \(path) (annotation \(annID))")
+            if let ann = ev["annotation"] as? [String: Any] {
+                let note = (ann["note"] as? String) ?? ""
+                if !note.isEmpty {
+                    lines.append("    Note: \(note)")
+                }
+                if let thread = ann["thread"] as? [[String: Any]], !thread.isEmpty {
+                    if let last = thread.last,
+                       let mAuthor = last["author"] as? String,
+                       let mText = last["text"] as? String {
+                        lines.append("    Latest message (\(mAuthor)): \(mText)")
+                    }
+                }
+            }
+        }
+        return textContent(lines.joined(separator: "\n"))
+    }
+```
+
+Pass `clientID` through `callMindle` automatically — Task 4 already added it to every request body.
+
+- [ ] **Step 3: Verify build**
+
+Run: `./build.sh 2>&1 | tail -5`
+Expected: `✓ Built build/Mindle.app`
+
+- [ ] **Step 4: Smoke test tools/list**
+
+```bash
+printf '%s\n' '{"jsonrpc":"2.0","id":1,"method":"tools/list","params":{}}' \
+  | /Users/neptune/workdir/mindle/build/Mindle.app/Contents/MacOS/mindle-mcp \
+  | python3 -c 'import sys,json
+for line in sys.stdin:
+  obj = json.loads(line)
+  for t in obj.get("result",{}).get("tools",[]):
+    print(t["name"])'
+```
+
+Expected: six lines — `list_open_files`, `get_annotations`, `clear_annotation`, `comment_on_annotation`, `create_annotation`, `wait_for_annotation_event`.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add Sources/MindleMCP/main.swift
+git commit -m "mindle-mcp: expose wait_for_annotation_event tool"
+```
+
+---
+
+## Task 8: End-to-end smoke test against running Mindle
+
+**Files:**
+- No code changes; manual verification only.
+
+- [ ] **Step 1: Install the new build**
+
+```bash
+osascript -e 'quit app "Mindle"'
+sleep 1
+rm -rf /Applications/Mindle.app
+cp -R /Users/neptune/workdir/mindle/build/Mindle.app /Applications/
+open /Applications/Mindle.app
+```
+
+Open a Markdown file in Mindle.
+
+- [ ] **Step 2: Confirm baseline tools still work after client_id changes**
+
+```bash
+printf '%s\n' \
+  '{"jsonrpc":"2.0","id":1,"method":"tools/call","params":{"name":"list_open_files","arguments":{}}}' \
+  | /Applications/Mindle.app/Contents/MacOS/mindle-mcp
+```
+
+Expected: response listing the file you opened, no error.
+
+- [ ] **Step 3: Timeout path — wait_for_annotation_event with nothing pending**
+
+```bash
+printf '%s\n' \
+  '{"jsonrpc":"2.0","id":1,"method":"tools/call","params":{"name":"wait_for_annotation_event","arguments":{"timeout_seconds":5}}}' \
+  | /Applications/Mindle.app/Contents/MacOS/mindle-mcp
+```
+
+Expected: blocks for ~5s, then returns `content` with text "No new events. last_event_id=0" (or whatever the current id is).
+
+- [ ] **Step 4: Event path — wait then annotate**
+
+Open two terminals. In terminal A:
+
+```bash
+printf '%s\n' \
+  '{"jsonrpc":"2.0","id":1,"method":"tools/call","params":{"name":"wait_for_annotation_event","arguments":{"timeout_seconds":60}}}' \
+  | /Applications/Mindle.app/Contents/MacOS/mindle-mcp
+```
+
+In Mindle, highlight a passage and add a note (⌘⇧N), type "test", press Return.
+
+Terminal A should return within a few seconds with one `created` event. Inspect the JSON for `events: [{event_id: 1, type: "created", path: "...", annotation: {...}}]`.
+
+- [ ] **Step 5: Self-filter path — agent's own mutation doesn't wake itself**
+
+In one shell, start a wait then pipe a comment to the same helper instance via JSON-RPC. The simplest way is to send two requests through the same helper invocation:
+
+```bash
+printf '%s\n' \
+  '{"jsonrpc":"2.0","id":1,"method":"tools/call","params":{"name":"comment_on_annotation","arguments":{"path":"<your path>","id":"<your annotation id>","text":"self-filter test"}}}' \
+  '{"jsonrpc":"2.0","id":2,"method":"tools/call","params":{"name":"wait_for_annotation_event","arguments":{"timeout_seconds":5}}}' \
+  | /Applications/Mindle.app/Contents/MacOS/mindle-mcp
+```
+
+Expected: the first response confirms the comment posted; the second response — using the same helper-process clientID — returns "No new events" (the agent's own comment was filtered).
+
+Open Mindle and verify the agent's comment IS visible in the annotation's thread (gray stripe). So the comment landed; only the wait was filtered.
+
+- [ ] **Step 6: Multi-client visibility — second helper instance sees the first's mutations**
+
+In terminal A, start a wait:
+
+```bash
+printf '%s\n' \
+  '{"jsonrpc":"2.0","id":1,"method":"tools/call","params":{"name":"wait_for_annotation_event","arguments":{"timeout_seconds":30}}}' \
+  | /Applications/Mindle.app/Contents/MacOS/mindle-mcp
+```
+
+In terminal B (a different helper invocation = different clientID), post a comment to an existing annotation:
+
+```bash
+printf '%s\n' \
+  '{"jsonrpc":"2.0","id":1,"method":"tools/call","params":{"name":"comment_on_annotation","arguments":{"path":"<your path>","id":"<your annotation id>","text":"from other client"}}}' \
+  | /Applications/Mindle.app/Contents/MacOS/mindle-mcp
+```
+
+Terminal A should return immediately with a `thread_reply` event (different clientID = not filtered).
+
+- [ ] **Step 7: UI integration — agent's MCP wait loop receives a user event**
+
+In Claude Code, with the running session:
+- Ask "watch my Mindle annotations and answer them" — the agent should call `wait_for_annotation_event` in a loop.
+- Add an annotation in Mindle (⌘⇧N, "say hi").
+- The agent should pick it up and respond via `comment_on_annotation`.
+- Click Reply on the thread, type a follow-up, Return — the agent should pick THAT up too.
+
+If any step fails, file a TODO note on which step and what was observed. The plan does not require fixing in this PR — the watch primitive is delivered; behavior polish can iterate.
+
+- [ ] **Step 8: Push branch and open PR**
+
+```bash
+git push -u origin feat/mcp-watch
+gh pr create --base main \
+  --title "MCP Phase 3: wait_for_annotation_event for ambient collaboration" \
+  --body "$(cat <<'EOF'
+## Summary
+- New MCP tool wait_for_annotation_event letting an agent run an ambient loop: the user annotates in Mindle, the agent picks it up automatically and addresses it.
+- AnnotationEventLog backs the long-poll with a 256-event ring buffer + waiter primitives, MainActor-isolated.
+- Self-filtering via per-helper clientID: the agent's own mutations never wake the agent.
+- Works in any MCP client (Claude Code, Codex, Cursor) — pure MCP, no client-specific hooks.
+
+Builds on #11 (Phase 2). Spec: docs/superpowers/specs/2026-05-11-ambient-mindle-collaboration-design.md.
+
+## Test plan
+- [ ] list_open_files / get_annotations / clear_annotation / comment_on_annotation / create_annotation all still return clean responses.
+- [ ] wait_for_annotation_event with timeout=5 and nothing pending returns "No new events".
+- [ ] User adds annotation in Mindle while a wait is pending → wait returns within a few seconds with one `created` event.
+- [ ] Agent's own comment_on_annotation does NOT wake its own wait (filtered via clientID).
+- [ ] Second helper instance's mutation DOES wake the first's wait.
+- [ ] Full Claude Code session: "watch my Mindle annotations" → agent loops → user annotates → agent responds.
+
+🤖 Generated with Claude Code
+EOF
+)"
+```
+
+---
+
+## Self-Review
+
+Reviewed the plan against the spec:
+
+**Spec coverage:**
+- `wait_for_annotation_event` tool with timeout + since_event_id + gap → Tasks 5, 6, 7.
+- Self-filter via client_id → Tasks 3, 4 (threading) + Task 5 (filter in snapshot/wait) + Task 6 (excludingClientID in dispatch).
+- 256-event ring buffer → Task 1 (capacity constant) + Task 1's `events.removeFirst` trim.
+- Gap detection → Task 1's `snapshot` returns `gap: true` when `sinceID < oldestID - 1`.
+- Event payload includes path, annotation, message_id where applicable → Task 6's encoding.
+- Cross-agent portability → Tool description in Task 7 carries the protocol guidance; no Claude Code dependency.
+- Optional Claude Code skill (`docs/skills/mindle-collaboration.md`) — **Spec marks this as "optional but bundled"; not in this plan.** Following YAGNI: ship the tool, see how it feels, write the skill as a Phase 3b once the protocol is proven. If the user wants the skill in this PR, it's a small append.
+- Reconnection / gap handling → Task 1's snapshot handles `since_event_id < oldest`. Tasks 6/7 surface the gap flag to the agent.
+- Acceptance criteria 1–6 are all covered by Task 8's manual smoke steps.
+
+**Placeholder scan:** No TBD/TODO. All code blocks are complete. Manual verification steps have concrete commands and expected outputs.
+
+**Type consistency:**
+- `AnnotationEvent.Kind` enum (`.created`, `.threadReply`, `.deleted`) is used consistently — Task 1 defines, Task 2 calls with `.created`/`.deleted`/`.threadReply`, Task 6 reads `.rawValue` to render to JSON.
+- `clientID: String?` is consistent across DocumentStore, AppDelegate, MCPServer, AnnotationEventLog.
+- `snapshot` returns the same tuple shape `(events, lastEventID, gap)` used by `wait`.
+
+**Scope check:** Single subsystem (one new tool + supporting plumbing). Reasonable for a single PR.
+
+No issues to fix; proceeding to handoff.

--- a/docs/superpowers/specs/2026-05-11-ambient-mindle-collaboration-design.md
+++ b/docs/superpowers/specs/2026-05-11-ambient-mindle-collaboration-design.md
@@ -1,0 +1,176 @@
+# Ambient Mindle Collaboration — Design
+
+**Date:** 2026-05-11
+**Status:** Approved for implementation
+**Branch target:** new `feat/mcp-watch` off `feat/mcp-phase2`
+
+## Problem
+
+Phase 2 shipped a working collaboration loop, but it's strictly request-driven: the user has to *ask* the agent to look at the file ("check my annotations"). The desired experience is the opposite — the user annotates in Mindle and the agent picks them up on its own and answers, without being prompted each time. Mindle becomes a parallel conversation surface: the user adds notes in the document, the agent responds inline in the threads, and continuity lives in the file + threads rather than in chat history.
+
+## Goals
+
+- The agent picks up new annotations and thread replies on its own while a watch session is active.
+- Works in **any MCP client** (Claude Code, Codex, Cursor, custom agents) — no client-specific glue required.
+- The agent's behavior is described well enough by the MCP tool surface that a vanilla agent (no skill) can run the loop just by being told "watch my Mindle annotations."
+- Optional Claude Code skill makes invocation frictionless but is not required for correctness.
+
+## Non-Goals (v1)
+
+- **Cold wake from annotation.** The agent must already be running with a watch session active. We do not spawn agents from OS-level hooks. (Considered and rejected; revisit as Phase 4.)
+- **Mid-edit reactivity.** Watch fires on annotation lifecycle events (create / thread-reply / delete), not while the user is typing the note. The reply Return-to-commit gesture is the commit point.
+- **Cross-window event ordering guarantees.** If the user has two windows on the same file and annotates in both at once, the agent sees both events in close succession but no strict ordering guarantee beyond per-window monotonicity.
+
+## Architecture
+
+```
+┌──────────────────┐         ┌──────────────────────┐         ┌──────────────────┐
+│  Mindle (server) │         │   mindle-mcp helper  │         │      Agent       │
+│                  │         │                      │         │                  │
+│ DocumentStore    │         │ stdio JSON-RPC ←─────┼─────────┼─ tools/call     │
+│ mutation         │         │                      │         │   wait_for_…    │
+│   │              │         │ socket request ──────┼─→ Mindle│                  │
+│   ▼              │  pushes │   {op:"wait_for_…",  │         │                  │
+│ event buffer ────┼────────►│    since_event_id,   │         │                  │
+│ (per-session)    │  events │    timeout_seconds}  │         │                  │
+│                  │  ◄──────│                      │         │                  │
+│                  │ response│ socket response ◄────┤         │ result with     │
+│                  │         │   {events:[…]}       ├────────►│ event payload  │
+└──────────────────┘         └──────────────────────┘         └──────────────────┘
+```
+
+The socket protocol stays length-prefixed JSON. A new op `wait_for_annotation_event` carries the long-poll semantics. The helper blocks on the socket read until Mindle responds. Mindle responds either when an event arrives or when its own timeout elapses.
+
+### Why long-poll vs MCP server notifications
+
+MCP servers *can* send notifications, but in practice MCP clients route only a fixed set (`notifications/tools/list_changed`, `notifications/resources/updated`, etc.) to internal handlers; arbitrary application-level notifications don't reliably become agent-visible context. A request/response tool call with a timeout is the most portable contract and works in every MCP client today.
+
+## Event Model
+
+### Wakeup-worthy events
+
+Three types wake the agent:
+
+1. `annotation_created` — user added a new annotation (highlight or note)
+2. `thread_reply` — user added a message to an existing annotation's thread
+3. `annotation_deleted` — user deleted an annotation
+
+Events authored by the agent (agent-created annotations, agent thread comments, agent clears) are filtered server-side and **never** wake the agent. This prevents self-driven loops.
+
+Annotation note edits do not wake the agent (rare; user can re-annotate if they truly need a fresh take).
+
+### Event payload
+
+```json
+{
+  "event_id": 42,
+  "type": "thread_reply",
+  "path": "/abs/path/to/file.md",
+  "annotation_id": "UUID",
+  "annotation": { /* same shape as get_annotations entry, includes thread */ },
+  "message_id": "UUID",      // only for thread_reply
+  "occurred_at": "ISO-8601"
+}
+```
+
+Every event carries the file path so the agent always knows where the event occurred without needing a separate lookup. The full annotation (including its thread) is embedded so the agent can act on a single payload without an extra `get_annotations` round-trip.
+
+### Per-session event log
+
+Mindle maintains a monotonic `event_id` counter per app launch. The event log is in-memory (no persistence across Mindle restarts — that's a re-list-and-resync on the agent side, see Reconnection). When a wakeup-worthy event happens, Mindle appends it to the log and signals any waiting `wait_for_annotation_event` consumer.
+
+The log retains the last **256 events** in memory. Older events are dropped — agents that fall further behind get a `gap` signal (see Reconnection).
+
+## MCP Tool Surface
+
+One new tool:
+
+```
+wait_for_annotation_event(
+  timeout_seconds: int = 60,         // server clamps to [5, 300]
+  since_event_id: int | null = null  // returned by previous call
+) → {
+  events: [Event, …],   // possibly empty if timeout elapsed
+  last_event_id: int,   // pass this as since_event_id in the next call
+  gap: bool             // true if events were dropped between since_event_id and now
+}
+```
+
+The agent's loop:
+
+```
+baseline:
+  files = list_open_files()
+  for path in files: get_annotations(path)
+  last = null
+
+watch:
+  while running:
+    resp = wait_for_annotation_event(timeout_seconds=60, since_event_id=last)
+    if resp.gap:
+      // we fell behind; rebaseline
+      for path in list_open_files(): get_annotations(path)
+    for event in resp.events:
+      handle(event)
+    last = resp.last_event_id
+```
+
+`handle(event)` is the agent's policy: for `created` and `thread_reply` it reads the surrounding file context and either edits the file then clears, or posts a `comment_on_annotation` reply. For `deleted` it acknowledges silently (no action; the agent might briefly note the deletion in its own chain of thought).
+
+## Reconnection and Gap Handling
+
+The helper can be restarted (e.g., user quits and reopens Claude Code), or Mindle can be restarted. Three cases:
+
+1. **Helper restart, Mindle alive.** Agent's first `wait_for_annotation_event` after restart passes the last known `event_id` (if it persisted state) or `null` (cold start). If `since_event_id < oldest_in_log`, Mindle returns `gap: true` and the agent re-baselines. If `null`, Mindle returns events from now forward — the agent re-baselines anyway as part of session start.
+2. **Mindle restart.** Mindle's event_id counter resets to 0 on launch. The agent's old `since_event_id` is now ahead of Mindle's; Mindle treats this as `since_event_id=null` and the agent rebaselines.
+3. **Long idle.** If the agent's loop sleeps in `wait_for_annotation_event` for the full timeout with no events, it gets an empty array and a refreshed `last_event_id` (== input `since_event_id`) — no rebaseline needed. The loop continues.
+
+Cold-start state is not persisted across helper restarts. Agents that care about not missing events while the helper was down can persist `last_event_id` themselves (e.g., in a project state file); without that, restart = rebaseline.
+
+## Filtering Self-Authored Events
+
+The agent's own MCP calls — `clear_annotation`, `comment_on_annotation`, `create_annotation` — must not wake the agent. Because the current helper opens a fresh Unix-socket connection per request (see `callMindle` in `Sources/MindleMCP/main.swift`), socket identity alone can't link a mutation to a wait call — they ride on different connections.
+
+Instead, the helper generates a `client_id` (UUID) once at startup and includes it in every JSON request body it sends to Mindle. Mindle's `MCPServer.dispatch` reads `request["client_id"]` and, for mutating ops, tags the event it appends to the log with that id. When `wait_for_annotation_event` returns events for a given `client_id`, events whose tag matches that client_id are filtered out.
+
+Result: the agent never sees its own mutations as wakeup events, regardless of how many separate socket calls the helper makes. Other clients (a second agent, user actions through the Mindle UI, untagged sources like the file watcher) still see those events normally.
+
+## Cross-Agent Portability
+
+The tool description on `wait_for_annotation_event` carries the protocol guidance verbatim — what to call before entering the loop, how to handle events, what `gap` means, when to stop. Any MCP client can run this loop by being told "watch my Mindle annotations and answer them as they come in." No client-specific glue.
+
+The Claude Code skill (next section) is a convenience for invocation, not a requirement for correctness.
+
+## Optional Claude Code Skill
+
+`docs/skills/mindle-collaboration.md` (bundled with the app and instructable via setup menu): a Claude Code skill that codifies the watch loop with project-tuned heuristics — e.g., when to comment-and-wait vs edit-and-clear, how to handle conflicting annotations, what counts as "user said stop." Users invoke it as `/mindle-collaboration` or by natural prompt. Skill body has the full protocol; tool descriptions have the same protocol in abbreviated form so non-skill agents work too.
+
+## Edge Cases
+
+| Case | Behavior |
+|------|----------|
+| Two windows on the same file, user annotates in one | Agent gets one event, addresses it, both windows reflect the result via shared sidecar |
+| User adds annotation A, agent starts addressing, user adds annotation B | Both events queued; agent finishes A's thread, then sees B on next wait call |
+| Agent posts a comment; user replies in same second | Agent's mutation event is filtered (self); user's reply wakes agent on next wait |
+| User closes the file while agent is mid-edit | File still exists on disk; agent's edit succeeds; on reopen, user sees the diff banner |
+| User quits Mindle mid-watch | Helper's next socket call fails; helper returns an error; agent's wait returns an error; agent exits loop |
+| Mindle restarts while agent is mid-wait | Helper's socket read returns EOF; helper returns error; agent reconnects on next call and rebaselines |
+
+## Phase 4 Future Work (out of scope here)
+
+- **Cold-wake hook.** Mindle-side configurable shell command on annotation events, for users who want a fresh `claude` session spawned automatically. Different security model (what can the hook do?), different UX (one-shot session). Layer on top of, not instead of, the watch loop.
+- **Diff-chunk chip surfacing.** When the agent clears an annotation with a summary, show the summary as a hoverable chip on the corresponding diff chunk in the reader. Closes the user-side review loop visually.
+- **Multi-agent sessions.** Currently each MCP socket connection is one agent. If multiple agents are watching the same Mindle, they each get full events (other-agent mutations are NOT filtered). Future work: a `consume` flag so an agent can claim an annotation, preventing others from acting on it.
+
+## Acceptance Criteria
+
+1. User adds an annotation in Mindle; agent's running watch loop receives `annotation_created` event with full payload, including file path.
+2. User replies in a thread; agent receives `thread_reply` event including the full thread.
+3. Agent's own `comment_on_annotation` call does NOT trigger a wakeup event on the wait call sharing the same `client_id`.
+4. Agent stops by killing the wait loop with a user prompt; Mindle has no zombie state.
+5. After Mindle restart, agent's next `wait_for_annotation_event` returns `gap: true` and the agent rebaselines.
+6. Default timeout (60s) elapses with no events → agent receives `{events: [], gap: false}` and continues.
+
+## Open Questions
+
+None at this time — all scope questions resolved during brainstorming.


### PR DESCRIPTION
## Summary

Builds on #11 (Phase 2). Adds one new MCP tool — `wait_for_annotation_event` — that lets an agent run an ambient collaboration loop: the user annotates in Mindle, the agent picks up the event without being prompted and addresses it, then waits for the next.

- `AnnotationEventLog` (MainActor singleton) backs the long-poll with a 256-event ring buffer + `withCheckedContinuation`-based waiters.
- Self-filtering via per-helper `clientID`: the helper generates one UUID at startup and stamps every request; Mindle tags mutations with it and excludes the caller's own events from their wait response. Agent never wakes on its own writes.
- Pure MCP — works in any client (Claude Code, Codex, Cursor) without client-specific hooks. The tool description carries the full protocol so even a vanilla agent runs the loop just by being told "watch my Mindle annotations."

Spec + plan:
- `docs/superpowers/specs/2026-05-11-ambient-mindle-collaboration-design.md`
- `docs/superpowers/plans/2026-05-11-ambient-mindle-collaboration.md`

## Test plan

- [x] Baseline `list_open_files` still works after `client_id` stamping
- [x] `wait_for_annotation_event` with no pending events + 5-6s timeout returns "No new events. last_event_id=0"
- [ ] User adds annotation in Mindle while a wait is pending → wait returns with one `created` event carrying the full annotation payload
- [ ] User replies in an existing thread → `thread_reply` event returns with the post-mutation annotation
- [ ] User deletes annotation → `deleted` event returns
- [ ] Agent's own `comment_on_annotation` does NOT wake its own wait (same helper UUID, filtered)
- [ ] Second helper instance's mutation DOES wake the first's wait
- [ ] Full Claude Code loop: "watch my Mindle annotations" → agent calls wait_for_annotation_event in a loop → user annotates → agent responds via comment_on_annotation → loop continues

Phase 4 follow-ups (out of scope, deferred): cold-wake via Mindle-side hook, diff-chunk chip surfacing for cleared annotations, bundled `mindle-collaboration` skill for Claude Code.