### PR TITLE
Relicense v2.0+ as MIT + Commons Clause

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,3 +1,21 @@
+Mindle License
+
+This LICENSE governs version 2.0 and later of Mindle. Earlier versions
+(v1.x) were released under the MIT License and remain available under
+those terms — see the historical LICENSE in the corresponding v1.x
+release tags on GitHub.
+
+Versions 2.0 and later are licensed under the MIT License with the
+addition of the Commons Clause license condition, reproduced in full
+below. In short: the source is open, you may copy, modify, distribute,
+sublicense, and use the Software freely — but you may not "Sell" the
+Software, as defined by the Commons Clause, without a separate
+commercial agreement with the Licensor.
+
+For commercial licensing inquiries, please contact the Licensor.
+
+────────────────────────────────────────────────────────────────────
+
 MIT License
 
 Copyright (c) 2026 Fabio Nonato
@@ -19,3 +37,27 @@ AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
 LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
 OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.
+
+────────────────────────────────────────────────────────────────────
+
+"Commons Clause" License Condition v1.0
+
+The Software is provided to you by the Licensor under the License, as
+defined below, subject to the following condition.
+
+Without limiting other conditions in the License, the grant of rights
+under the License will not include, and the License does not grant to
+you, the right to Sell the Software.
+
+For purposes of the foregoing, "Sell" means practicing any or all of
+the rights granted to you under the License to provide to third parties,
+for a fee or other consideration (including without limitation fees for
+hosting or consulting/support services related to the Software), a
+product or service whose value derives, entirely or substantially, from
+the functionality of the Software. Any license notice or attribution
+required by the License must also include this Commons Clause License
+Condition notice.
+
+Software: Mindle (versions 2.0 and later)
+License: MIT
+Licensor: Fabio Nonato

--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@
 <p align="center">
   <img src="https://img.shields.io/badge/platform-macOS%2014%2B-blue?style=flat-square" alt="macOS 14+">
   <img src="https://img.shields.io/badge/swift-6.x-orange?style=flat-square" alt="Swift 6">
-  <img src="https://img.shields.io/github/license/nonatofabio/mindle?style=flat-square" alt="MIT License">
+  <img src="https://img.shields.io/badge/license-MIT%20%2B%20Commons%20Clause-blue?style=flat-square" alt="MIT + Commons Clause (v2.0+)">
   <img src="https://img.shields.io/github/actions/workflow/status/nonatofabio/mindle/build.yml?style=flat-square&label=build" alt="Build status">
   <img src="https://img.shields.io/github/downloads/nonatofabio/mindle/total?style=flat-square&label=downloads" alt="Total downloads">
 </p>
@@ -127,4 +127,6 @@ The big-picture plan lives in [`docs/v2-roadmap.md`](docs/v2-roadmap.md). Headli
 
 ## License
 
-[MIT](LICENSE) — use it, fork it, make it yours.
+Mindle **v2.0 and later** is licensed under [**MIT + Commons Clause**](LICENSE). Use it, fork it, modify it, embed it in your own work — same MIT freedoms you'd expect — with one added condition: you may not *Sell* the Software (or sell hosting / support / services whose value derives substantially from it) without a separate commercial agreement. For commercial licensing inquiries, please get in touch.
+
+Versions **v1.x** were released under the pure [MIT License](https://opensource.org/license/mit/) and remain available under those terms in the corresponding v1.x release tags.


### PR DESCRIPTION
Mindle v1.x stays under pure MIT (already-released code can't be
revoked, and we don't want to). Starting at v2.0 the license adds
the canonical Commons Clause condition: copy/fork/modify/use stay
fully open, but Selling the Software (or selling hosting/support
services whose value derives substantially from it) requires a
separate commercial agreement with the Licensor.

LICENSE now contains a header explaining the version scope, the
full MIT text (unchanged), and the verbatim Commons Clause v1.0
text with Software/License/Licensor fields filled in.

README license section and badge updated to match. The shields.io
badge is hand-rolled because Commons Clause isn't an SPDX
identifier the auto-detector recognises.