### PR TITLE
feat: team collaboration layer — unified .collab.json sidecar

### DIFF
--- a/Resources/web/collab-bridge.js
+++ b/Resources/web/collab-bridge.js
@@ -50,6 +50,10 @@ const CollabBridge = (() => {
     post("collabRefresh", {});
   }
 
+  function requestIdentityChange() {
+    post("collabIdentityChange", {});
+  }
+
   function scrollToAnchor(anchor) {
     post("collabScrollToAnchor", anchor);
   }
@@ -84,6 +88,7 @@ const CollabBridge = (() => {
     sendLabel,
     requestNewComment,
     sendRefresh,
+    requestIdentityChange,
     scrollToAnchor,
     scrollPanelToComment,
     receiveComments,

--- a/Resources/web/collab-bridge.js
+++ b/Resources/web/collab-bridge.js
@@ -1,0 +1,95 @@
+// collab-bridge.js — Bidirectional bridge between the panel WKWebView and Swift.
+// Outbound (JS → Swift): posts messages via webkit.messageHandlers.
+// Inbound (Swift → JS): Swift calls these functions via evaluateJavaScript.
+// Pattern: JS actions → Swift handler → engine mutation → Swift pushes updated state back.
+
+// Debug utility — writes to the #debug-log element when the 🐛 toggle is active.
+// Harmless no-op when the debug panel is hidden.
+function dbg(msg) {
+  const el = document.getElementById('debug-log');
+  if (el) {
+    const t = new Date().toLocaleTimeString('en-GB', {hour:'2-digit',minute:'2-digit',second:'2-digit'});
+    el.innerHTML += `[${t}] ${msg}<br>`;
+    el.scrollTop = el.scrollHeight;
+  }
+}
+
+const CollabBridge = (() => {
+  // Send message to Swift via webkit.messageHandlers
+  function post(handler, payload) {
+    dbg(`→ Swift: ${handler}`);
+    if (window.webkit?.messageHandlers?.[handler]) {
+      window.webkit.messageHandlers[handler].postMessage(payload);
+    } else {
+      console.log(`[CollabBridge] ${handler}:`, payload);
+    }
+  }
+
+  // Outbound: JS → Swift
+  function sendReply(commentId, author, body) {
+    post("collabReply", { commentId, author, body });
+  }
+
+  function sendResolve(commentId, resolvedBy) {
+    post("collabResolve", { commentId, resolvedBy });
+  }
+
+  function sendAssign(commentId, assignee) {
+    post("collabAssign", { commentId, assignee });
+  }
+
+  function sendLabel(commentId, label) {
+    post("collabLabel", { commentId, label });
+  }
+
+  function requestNewComment() {
+    post("collabNewComment", {});
+  }
+
+  function sendRefresh() {
+    post("collabRefresh", {});
+  }
+
+  function scrollToAnchor(anchor) {
+    post("collabScrollToAnchor", anchor);
+  }
+
+  function scrollPanelToComment(commentId) {
+    const card = document.querySelector(`.comment-card[data-id="${commentId}"]`);
+    if (card) card.scrollIntoView({ behavior: "smooth", block: "center" });
+  }
+
+  // Inbound: Swift → JS (called via evaluateJavaScript)
+  function receiveComments(json) {
+    const data = typeof json === "string" ? JSON.parse(json) : json;
+    dbg(`← Swift: receiveComments (${Array.isArray(data) ? data.length : '?'} items)`);
+    CollabPanel.setComments(data);
+    CollabHighlights.applyHighlights(data);
+  }
+
+  function receiveTheme(theme) {
+    document.documentElement.setAttribute("data-theme", theme);
+  }
+
+  function receiveUser(user) {
+    dbg(`← Swift: receiveUser('${user}')`);
+    CollabPanel.init(user);
+  }
+
+  // Expose inbound API globally for evaluateJavaScript calls
+  window.CollabBridge = {
+    sendReply,
+    sendResolve,
+    sendAssign,
+    sendLabel,
+    requestNewComment,
+    sendRefresh,
+    scrollToAnchor,
+    scrollPanelToComment,
+    receiveComments,
+    receiveTheme,
+    receiveUser,
+  };
+
+  return window.CollabBridge;
+})();

--- a/Resources/web/collab-highlights.js
+++ b/Resources/web/collab-highlights.js
@@ -1,0 +1,106 @@
+// MarkCollab — Inline Highlight Overlays for the Markdown Pane
+
+const CollabHighlights = (() => {
+  const HIGHLIGHT_CLASS = "collab-highlight";
+  let activeHighlights = [];
+
+  function applyHighlights(comments) {
+    clearHighlights();
+    comments.filter(c => c.status === "open").forEach(c => {
+      const range = findAnchorRange(c.anchor);
+      if (range) highlight(range, c);
+    });
+  }
+
+  function clearHighlights() {
+    activeHighlights.forEach(el => {
+      const parent = el.parentNode;
+      if (parent) {
+        parent.replaceChild(document.createTextNode(el.textContent), el);
+        parent.normalize();
+      }
+    });
+    activeHighlights = [];
+  }
+
+  function highlight(range, comment) {
+    const mark = document.createElement("mark");
+    mark.className = HIGHLIGHT_CLASS;
+    mark.dataset.commentId = comment.id;
+    mark.style.backgroundColor = (comment._color || "#4A90D9") + "33";
+    mark.style.borderBottom = `2px solid ${comment._color || "#4A90D9"}`;
+    mark.style.cursor = "pointer";
+    mark.title = `${comment.thread?.[0]?.author}: ${comment.thread?.[0]?.body?.slice(0, 50) || ""}`;
+    mark.onclick = () => CollabBridge.scrollPanelToComment(comment.id);
+
+    try {
+      range.surroundContents(mark);
+      activeHighlights.push(mark);
+    } catch {
+      // Range crosses element boundaries; fall back to simple insert
+      const fragment = range.extractContents();
+      mark.appendChild(fragment);
+      range.insertNode(mark);
+      activeHighlights.push(mark);
+    }
+  }
+
+  function scrollToAnchor(anchor) {
+    const mark = document.querySelector(`[data-comment-id="${anchor._commentId || ""}"]`);
+    if (mark) {
+      mark.scrollIntoView({ behavior: "smooth", block: "center" });
+      mark.style.transition = "background-color 0.3s";
+      mark.style.backgroundColor = (anchor._color || "#4A90D9") + "66";
+      setTimeout(() => { mark.style.backgroundColor = (anchor._color || "#4A90D9") + "33"; }, 1500);
+      return;
+    }
+    // Fallback: text search
+    const range = findAnchorRange(anchor);
+    if (range) {
+      const el = range.startContainer.parentElement;
+      if (el) el.scrollIntoView({ behavior: "smooth", block: "center" });
+    }
+  }
+
+  function findAnchorRange(anchor) {
+    if (!anchor?.text) return null;
+    const body = document.body;
+    const walker = document.createTreeWalker(body, NodeFilter.SHOW_TEXT);
+    const searchText = (anchor.prefix || "") + anchor.text + (anchor.suffix || "");
+
+    let node;
+    let fullText = "";
+    const nodes = [];
+
+    while ((node = walker.nextNode())) {
+      nodes.push({ node, start: fullText.length });
+      fullText += node.textContent;
+    }
+
+    // Find the anchor text within the full document text
+    const prefixLen = (anchor.prefix || "").length;
+    const idx = fullText.indexOf(anchor.text);
+    if (idx === -1) return null;
+
+    const startOffset = idx;
+    const endOffset = idx + anchor.text.length;
+
+    const startNode = nodes.find((n, i) => {
+      const next = nodes[i + 1];
+      return startOffset >= n.start && (!next || startOffset < next.start);
+    });
+    const endNode = nodes.find((n, i) => {
+      const next = nodes[i + 1];
+      return endOffset > n.start && (!next || endOffset <= next.start);
+    });
+
+    if (!startNode || !endNode) return null;
+
+    const range = document.createRange();
+    range.setStart(startNode.node, startOffset - startNode.start);
+    range.setEnd(endNode.node, endOffset - endNode.start);
+    return range;
+  }
+
+  return { applyHighlights, clearHighlights, scrollToAnchor };
+})();

--- a/Resources/web/collab-panel.css
+++ b/Resources/web/collab-panel.css
@@ -1,0 +1,348 @@
+/* MarkCollab Comment Panel — Themes & Layout */
+
+html, body {
+  margin: 0;
+  padding: 0;
+  height: 100%;
+  background: transparent;
+}
+
+:root, [data-theme="light"] {
+  --panel-bg: #FFFFFF;
+  --card-bg: #F8F9FA;
+  --text-primary: #1A1A1A;
+  --text-secondary: #6B7280;
+  --border: #E5E7EB;
+  --accent: #4A90D9;
+  --accent-hover: #357ABD;
+  --resolved: #34D399;
+  --wontfix: #9CA3AF;
+  --reply-bg: #F1F5F9;
+  --input-bg: #FFFFFF;
+  --shadow: rgba(0,0,0,0.08);
+}
+
+[data-theme="dark"] {
+  --panel-bg: #1E1E1E;
+  --card-bg: #2D2D2D;
+  --text-primary: #E5E5E5;
+  --text-secondary: #9CA3AF;
+  --border: #3D3D3D;
+  --accent: #5BA3EC;
+  --accent-hover: #4A90D9;
+  --resolved: #34D399;
+  --wontfix: #6B7280;
+  --reply-bg: #252525;
+  --input-bg: #353535;
+  --shadow: rgba(0,0,0,0.3);
+}
+
+[data-theme="sepia"] {
+  --panel-bg: #F5F0E8;
+  --card-bg: #EDE7DB;
+  --text-primary: #3D3229;
+  --text-secondary: #7A6B5D;
+  --border: #D4C9B8;
+  --accent: #8B6914;
+  --accent-hover: #6B5010;
+  --resolved: #5A9E6F;
+  --wontfix: #9E9080;
+  --reply-bg: #E8E0D4;
+  --input-bg: #F5F0E8;
+  --shadow: rgba(61,50,41,0.1);
+}
+
+/* Panel container */
+.collab-panel {
+  position: relative;
+  width: 100%;
+  height: 100%;
+  background: transparent;
+  border: none;
+  display: flex;
+  flex-direction: column;
+  font-family: -apple-system, BlinkMacSystemFont, "SF Pro Text", sans-serif;
+  font-size: 13px;
+  color: var(--text-primary);
+}
+
+/* Header */
+.collab-panel__header {
+  padding: 12px 16px;
+  border-bottom: 1px solid var(--border);
+  flex-shrink: 0;
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  flex-wrap: wrap;
+}
+.collab-panel__actions-bar {
+  display: flex;
+  align-items: center;
+  gap: 4px;
+  margin-left: auto;
+}
+.collab-panel__title {
+  font-size: 14px;
+  font-weight: 600;
+}
+.collab-panel__filter {
+  background: var(--input-bg);
+  border: 1px solid var(--border);
+  border-radius: 4px;
+  color: var(--text-primary);
+  font-size: 12px;
+  padding: 3px 6px;
+  cursor: pointer;
+}
+.collab-panel__sort {
+  background: var(--input-bg);
+  border: 1px solid var(--border);
+  border-radius: 4px;
+  color: var(--text-primary);
+  font-size: 12px;
+  padding: 3px 6px;
+  cursor: pointer;
+}
+.collab-panel__refresh {
+  background: none;
+  border: 1px solid var(--border);
+  border-radius: 4px;
+  color: var(--text-secondary);
+  font-size: 14px;
+  padding: 2px 6px;
+  cursor: pointer;
+  line-height: 1;
+}
+.collab-panel__refresh:hover {
+  border-color: var(--accent);
+  color: var(--accent);
+}
+.collab-panel__debug-toggle {
+  background: none;
+  border: none;
+  font-size: 12px;
+  cursor: pointer;
+  padding: 2px 4px;
+  opacity: 0.5;
+}
+
+/* Comment list */
+.collab-panel__list {
+  flex: 1;
+  overflow-y: auto;
+  min-height: 0;
+  padding: 8px;
+}
+
+/* Empty state */
+.collab-panel__empty {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  height: 100%;
+  padding: 32px;
+  text-align: center;
+  color: var(--text-secondary);
+  font-size: 13px;
+  line-height: 1.5;
+}
+
+/* Comment card */
+.comment-card {
+  background: var(--card-bg);
+  border: 1px solid var(--border);
+  border-radius: 8px;
+  padding: 12px;
+  margin-bottom: 8px;
+}
+
+.comment-card__header {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  margin-bottom: 6px;
+}
+.comment-card__dot {
+  width: 8px;
+  height: 8px;
+  border-radius: 50%;
+  flex-shrink: 0;
+}
+.comment-card__author {
+  font-weight: 600;
+  font-size: 12px;
+}
+.comment-card__time {
+  font-size: 11px;
+  color: var(--text-secondary);
+  margin-left: auto;
+}
+
+/* Status pill */
+.status-pill {
+  display: inline-block;
+  font-size: 10px;
+  font-weight: 600;
+  padding: 2px 6px;
+  border-radius: 10px;
+  text-transform: uppercase;
+  letter-spacing: 0.3px;
+}
+.status-pill--open { background: var(--accent); color: #fff; }
+.status-pill--resolved { background: var(--resolved); color: #fff; }
+.status-pill--wontfix { background: var(--wontfix); color: #fff; }
+
+/* Anchor snippet */
+.comment-card__anchor {
+  font-size: 12px;
+  color: var(--text-secondary);
+  background: var(--reply-bg);
+  border-left: 3px solid var(--accent);
+  padding: 4px 8px;
+  margin: 6px 0;
+  border-radius: 2px;
+  cursor: pointer;
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+.comment-card__anchor:hover {
+  color: var(--accent);
+}
+
+/* Assignee & labels */
+.comment-card__meta {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  margin: 6px 0;
+  flex-wrap: wrap;
+}
+.assignee-badge {
+  font-size: 11px;
+  background: var(--reply-bg);
+  border: 1px solid var(--border);
+  border-radius: 4px;
+  padding: 1px 6px;
+}
+.label-pill {
+  font-size: 10px;
+  padding: 1px 5px;
+  border-radius: 8px;
+  background: var(--border);
+  color: var(--text-secondary);
+}
+
+/* Thread */
+.comment-card__thread {
+  margin-top: 8px;
+  padding-left: 12px;
+  border-left: 2px solid var(--border);
+}
+.reply {
+  margin-bottom: 8px;
+}
+.reply__header {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  margin-bottom: 2px;
+}
+.reply__header .comment-card__dot {
+  width: 6px;
+  height: 6px;
+}
+.reply__author {
+  font-weight: 600;
+  font-size: 11px;
+}
+.reply__time {
+  font-size: 10px;
+  color: var(--text-secondary);
+}
+.reply__body {
+  font-size: 12px;
+  line-height: 1.4;
+  color: var(--text-primary);
+}
+
+/* Reply input */
+.comment-card__reply-box {
+  margin-top: 8px;
+  display: flex;
+  gap: 6px;
+}
+.comment-card__reply-box textarea {
+  flex: 1;
+  resize: none;
+  border: 1px solid var(--border);
+  border-radius: 4px;
+  padding: 6px 8px;
+  font-size: 12px;
+  font-family: inherit;
+  background: var(--input-bg);
+  color: var(--text-primary);
+  min-height: 32px;
+  max-height: 80px;
+}
+.comment-card__reply-box textarea:focus {
+  outline: none;
+  border-color: var(--accent);
+}
+.comment-card__reply-box button {
+  align-self: flex-end;
+  background: var(--accent);
+  color: #fff;
+  border: none;
+  border-radius: 4px;
+  padding: 6px 10px;
+  font-size: 12px;
+  font-weight: 500;
+  cursor: pointer;
+}
+.comment-card__reply-box button:hover {
+  background: var(--accent-hover);
+}
+
+/* Action bar */
+.comment-card__actions {
+  display: flex;
+  gap: 6px;
+  margin-top: 8px;
+  padding-top: 8px;
+  border-top: 1px solid var(--border);
+}
+.comment-card__actions button {
+  background: none;
+  border: 1px solid var(--border);
+  border-radius: 4px;
+  padding: 3px 8px;
+  font-size: 11px;
+  color: var(--text-secondary);
+  cursor: pointer;
+}
+.comment-card__actions button:hover {
+  border-color: var(--accent);
+  color: var(--accent);
+}
+
+/* New comment button (inline in header) */
+.collab-panel__fab-inline {
+  background: var(--accent);
+  color: #fff;
+  border: none;
+  border-radius: 4px;
+  font-size: 16px;
+  font-weight: 600;
+  width: 24px;
+  height: 24px;
+  line-height: 1;
+  cursor: pointer;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+}
+.collab-panel__fab-inline:hover {
+  background: var(--accent-hover);
+}

--- a/Resources/web/collab-panel.css
+++ b/Resources/web/collab-panel.css
@@ -104,6 +104,18 @@ html, body {
   padding: 3px 6px;
   cursor: pointer;
 }
+.collab-panel__identity {
+  font-size: 11px;
+  color: var(--text-secondary);
+  cursor: pointer;
+  margin-left: auto;
+  padding: 2px 6px;
+  border-radius: 4px;
+}
+.collab-panel__identity:hover {
+  background: var(--reply-bg);
+  color: var(--accent);
+}
 .collab-panel__refresh {
   background: none;
   border: 1px solid var(--border);

--- a/Resources/web/collab-panel.html
+++ b/Resources/web/collab-panel.html
@@ -27,6 +27,7 @@
         <option value="oldest">Oldest first</option>
         <option value="position">Doc position</option>
       </select>
+      <span class="collab-panel__identity" title="Click to change identity">● anonymous</span>
     </div>
 
     <!-- COMMENTS LIST: scrolls independently -->

--- a/Resources/web/collab-panel.html
+++ b/Resources/web/collab-panel.html
@@ -1,0 +1,50 @@
+<!DOCTYPE html>
+<html lang="en" data-theme="light">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>MarkCollab — Comments</title>
+  <link rel="stylesheet" href="collab-panel.css">
+</head>
+<body>
+  <div class="collab-panel">
+    <!-- HEADER: always pinned at top -->
+    <div class="collab-panel__header">
+      <span class="collab-panel__title">Comments (0 open)</span>
+      <div class="collab-panel__actions-bar">
+        <button class="collab-panel__fab-inline" aria-label="New comment" title="New Comment">+</button>
+        <button class="collab-panel__refresh" aria-label="Refresh" title="Refresh">↻</button>
+        <button class="collab-panel__debug-toggle" onclick="document.getElementById('debug-log').style.display=document.getElementById('debug-log').style.display==='none'?'block':'none'" title="Toggle debug">🐛</button>
+      </div>
+      <select class="collab-panel__filter" aria-label="Filter comments">
+        <option value="all">All</option>
+        <option value="open">Open</option>
+        <option value="resolved">Resolved</option>
+        <option value="mine">My Assignments</option>
+      </select>
+      <select class="collab-panel__sort" aria-label="Sort comments">
+        <option value="newest">Newest first</option>
+        <option value="oldest">Oldest first</option>
+        <option value="position">Doc position</option>
+      </select>
+    </div>
+
+    <!-- COMMENTS LIST: scrolls independently -->
+    <div class="collab-panel__list">
+      <div class="collab-panel__empty">No comments yet.<br>Select text and click + to start.</div>
+    </div>
+
+    <!-- DEBUG LOG: pinned at bottom, hidden by default -->
+    <div id="debug-log" style="display:none;max-height:120px;overflow-y:auto;background:#111;color:#0f0;font:10px monospace;padding:4px 6px;border-top:1px solid #333;flex-shrink:0;">[debug] panel loaded<br></div>
+  </div>
+
+  <script src="collab-highlights.js"></script>
+  <script src="collab-bridge.js"></script>
+  <script src="collab-panel.js"></script>
+  <script>
+    document.addEventListener("DOMContentLoaded", () => {
+      CollabPanel.init("ash");
+    });
+  </script>
+</body>
+</html>

--- a/Resources/web/collab-panel.js
+++ b/Resources/web/collab-panel.js
@@ -1,0 +1,291 @@
+// collab-panel.js — Comment panel rendering and interaction logic.
+// Receives comment data from Swift (via CollabBridge.receiveComments), renders
+// threaded comment cards, handles user actions (reply, resolve, assign, label),
+// and sends mutations back to Swift via webkit.messageHandlers.
+// Sections: init, data ingestion, rendering, card actions, filtering, helpers.
+
+const CollabPanel = (() => {
+  let comments = [];
+  let currentFilter = "all";
+  let currentSort = "newest";
+  let currentUser = "anonymous";
+
+  const el = (sel) => document.querySelector(sel);
+
+  function init(user) {
+    dbg('panel.init: ' + user);
+    currentUser = user || "anonymous";
+    bindFilter();
+    bindSort();
+    bindResize();
+    bindFAB();
+  }
+
+  function setComments(data) {
+    dbg('panel.setComments: ' + (data||[]).length + ' items');
+    comments = data || [];
+    render();
+  }
+
+  function render() {
+    dbg('panel.render: ' + comments.length + ' total');
+    const list = el(".collab-panel__list");
+    const filtered = sortComments(filterComments(comments));
+    const openCount = comments.filter(c => c.status === "open").length;
+
+    el(".collab-panel__title").textContent = `Comments (${openCount} open)`;
+
+    if (filtered.length === 0) {
+      list.innerHTML = `<div class="collab-panel__empty">No comments yet.<br>Select text and press ⌘⇧C to start.</div>`;
+      return;
+    }
+
+    list.innerHTML = filtered.map(renderCard).join("");
+    bindCardActions();
+  }
+
+  function filterComments(list) {
+    switch (currentFilter) {
+      case "open": return list.filter(c => c.status === "open");
+      case "resolved": return list.filter(c => c.status === "resolved");
+      case "mine": return list.filter(c => c.assignee === currentUser);
+      default: return list;
+    }
+  }
+
+  function renderCard(comment) {
+    const statusClass = `status-pill--${comment.status}`;
+    const anchorText = (comment.anchor?.text || "").slice(0, 60);
+    const labels = (comment.labels || []).map(l => `<span class="label-pill">${esc(l)}</span>`).join("");
+    const assignee = comment.assignee ? `<span class="assignee-badge">→ ${esc(comment.assignee)}</span>` : "";
+    const thread = (comment.thread || []).map(renderReply).join("");
+
+    const headerTime = fmtTime(threadTime(comment));
+
+    return `
+      <div class="comment-card" data-id="${esc(comment.id)}">
+        <div class="comment-card__header">
+          <span class="comment-card__dot" style="background:${authorColor(threadAuthor(comment))}"></span>
+          <span class="comment-card__author">${esc(threadAuthor(comment))}</span>
+          <span class="${statusClass} status-pill">${comment.status}</span>
+          ${headerTime ? `<span class="comment-card__time">· ${headerTime}</span>` : ""}
+        </div>
+        <div class="comment-card__anchor" data-anchor='${esc(JSON.stringify(comment.anchor))}'>${esc(anchorText)}</div>
+        <div class="comment-card__meta">${assignee}${labels}</div>
+        <div class="comment-card__thread">${thread}</div>
+        <div class="comment-card__reply-box">
+          <textarea placeholder="Reply…" rows="1"></textarea>
+          <button data-action="reply" data-id="${esc(comment.id)}">Reply</button>
+        </div>
+        <div class="comment-card__actions">
+          <button data-action="resolve" data-id="${esc(comment.id)}">Resolve</button>
+          <button data-action="assign" data-id="${esc(comment.id)}">Assign ▾</button>
+          <button data-action="labels" data-id="${esc(comment.id)}">Labels ▾</button>
+        </div>
+      </div>`;
+  }
+
+  function renderReply(reply) {
+    // Handle both old format (body/timestamp) and new unified format (text/createdAt)
+    const time = fmtTime(reply.timestamp || reply.createdAt);
+    return `
+      <div class="reply">
+        <div class="reply__header">
+          <span class="comment-card__dot" style="background:${authorColor(reply.author)}"></span>
+          <span class="reply__author">${esc(reply.author)}</span>
+          ${time ? `<span class="reply__time">· ${time}</span>` : ""}
+        </div>
+        <div class="reply__body">${esc(reply.body || reply.text)}</div>
+      </div>`;
+  }
+
+  function bindCardActions() {
+    document.querySelectorAll("[data-action='reply']").forEach(btn => {
+      btn.onclick = () => {
+        const card = btn.closest(".comment-card");
+        const textarea = card.querySelector("textarea");
+        const body = textarea.value.trim();
+        if (!body) return;
+        textarea.value = "";
+        CollabBridge.sendReply(card.dataset.id, currentUser, body);
+      };
+    });
+
+    document.querySelectorAll("[data-action='resolve']").forEach(btn => {
+      btn.onclick = () => CollabBridge.sendResolve(btn.dataset.id, currentUser);
+    });
+
+    document.querySelectorAll("[data-action='assign']").forEach(btn => {
+      btn.onclick = (e) => {
+        e.stopPropagation();
+        const names = Object.keys(collaborators);
+        if (names.length === 0) {
+          const name = prompt("Assign to:");
+          if (name) CollabBridge.sendAssign(btn.dataset.id, name);
+        } else {
+          showDropdown(btn, names, (name) => CollabBridge.sendAssign(btn.dataset.id, name));
+        }
+      };
+    });
+
+    document.querySelectorAll("[data-action='labels']").forEach(btn => {
+      btn.onclick = (e) => {
+        e.stopPropagation();
+        showDropdown(btn, ["question", "blocker", "nit", "todo", "suggestion"], (label) => {
+          CollabBridge.sendLabel(btn.dataset.id, label);
+        });
+      };
+    });
+
+    document.querySelectorAll(".comment-card__anchor").forEach(anchor => {
+      anchor.onclick = () => {
+        const data = JSON.parse(anchor.dataset.anchor);
+        CollabBridge.scrollToAnchor(data);
+      };
+    });
+  }
+
+  function bindFilter() {
+    const select = el(".collab-panel__filter");
+    if (!select) return;
+    select.onchange = () => {
+      currentFilter = select.value;
+      render();
+    };
+    const refresh = el(".collab-panel__refresh");
+    if (refresh) {
+      refresh.onclick = () => { dbg('CLICK: refresh'); CollabBridge.sendRefresh(); };
+    }
+  }
+
+  function bindSort() {
+    const select = el(".collab-panel__sort");
+    if (!select) return;
+    select.onchange = () => {
+      currentSort = select.value;
+      render();
+    };
+  }
+
+  function sortComments(list) {
+    switch (currentSort) {
+      case "newest":
+        return [...list].sort((a, b) => {
+          const ta = a.createdAt || a.thread?.[0]?.createdAt || a.thread?.[0]?.timestamp || "";
+          const tb = b.createdAt || b.thread?.[0]?.createdAt || b.thread?.[0]?.timestamp || "";
+          return tb.localeCompare(ta);
+        });
+      case "oldest":
+        return [...list].sort((a, b) => {
+          const ta = a.createdAt || a.thread?.[0]?.createdAt || a.thread?.[0]?.timestamp || "";
+          const tb = b.createdAt || b.thread?.[0]?.createdAt || b.thread?.[0]?.timestamp || "";
+          return ta.localeCompare(tb);
+        });
+      case "position":
+        return [...list].sort((a, b) => (a.anchor?.prefix || "").localeCompare(b.anchor?.prefix || ""));
+      default:
+        return list;
+    }
+  }
+
+  function bindResize() {
+    const handle = el(".collab-panel__resize");
+    const panel = el(".collab-panel");
+    if (!handle || !panel) return;
+
+    let startX, startW;
+    handle.onmousedown = (e) => {
+      startX = e.clientX;
+      startW = panel.offsetWidth;
+      handle.classList.add("active");
+      const onMove = (e2) => {
+        const diff = startX - e2.clientX;
+        panel.style.width = Math.max(240, Math.min(600, startW + diff)) + "px";
+      };
+      const onUp = () => {
+        handle.classList.remove("active");
+        document.removeEventListener("mousemove", onMove);
+        document.removeEventListener("mouseup", onUp);
+      };
+      document.addEventListener("mousemove", onMove);
+      document.addEventListener("mouseup", onUp);
+    };
+  }
+
+  function bindFAB() {
+    const fab = el(".collab-panel__fab-inline");
+    if (!fab) return;
+    fab.onclick = () => { dbg('CLICK: +FAB'); CollabBridge.requestNewComment(); };
+  }
+
+  // Dropdown menu for assign/labels
+  function showDropdown(anchor, items, onSelect) {
+    const existing = document.querySelector('.collab-dropdown');
+    if (existing) existing.remove();
+    const menu = document.createElement('div');
+    menu.className = 'collab-dropdown';
+    menu.style.cssText = 'position:absolute;z-index:9999;background:var(--card-bg);border:1px solid var(--border);border-radius:6px;padding:4px 0;box-shadow:0 4px 12px var(--shadow);min-width:120px;';
+    const rect = anchor.getBoundingClientRect();
+    menu.style.top = (rect.bottom + 4) + 'px';
+    menu.style.left = rect.left + 'px';
+    items.forEach(item => {
+      const opt = document.createElement('div');
+      opt.textContent = item;
+      opt.style.cssText = 'padding:5px 12px;font-size:12px;cursor:pointer;color:var(--text-primary);';
+      opt.onmouseenter = () => opt.style.background = 'var(--accent)';
+      opt.onmouseleave = () => opt.style.background = 'none';
+      opt.onclick = () => { menu.remove(); onSelect(item); };
+      menu.appendChild(opt);
+    });
+    document.body.appendChild(menu);
+    setTimeout(() => document.addEventListener('click', function rm() { menu.remove(); document.removeEventListener('click', rm); }), 0);
+  }
+
+  // Helpers
+  let collaborators = {};
+
+  function setCollaborators(collabs) { collaborators = collabs || {}; }
+
+  function threadAuthor(c) { return c.thread?.[0]?.author || "unknown"; }
+  function threadTime(c) { return c.thread?.[0]?.timestamp || c.thread?.[0]?.createdAt || ""; }
+
+  // Returns the collaborator's color from the pushed map, or a stable hash-based
+  // fallback if the author isn't in the map (ensures same author always gets same color).
+  function authorColor(author) {
+    if (collaborators[author]?.color) return collaborators[author].color;
+    const colors = ["#4A90D9","#E57373","#81C784","#FFB74D","#BA68C8","#4DD0E1","#F06292","#AED581"];
+    let h = 0;
+    for (let i = 0; i < (author||"").length; i++) h = ((h << 5) - h + author.charCodeAt(i)) | 0;
+    return colors[Math.abs(h) % colors.length];
+  }
+
+  // Formats an ISO 8601 timestamp as relative ("3h ago") for recent times,
+  // or absolute ("11 May, 6:00 PM") for anything older than a week.
+  function fmtTime(ts) {
+    if (!ts) return "";
+    const d = new Date(ts);
+    const now = Date.now();
+    const diff = now - d.getTime();
+    const mins = Math.floor(diff / 60000);
+    if (mins < 1) return "now";
+    if (mins < 60) return `${mins}m ago`;
+    const hrs = Math.floor(mins / 60);
+    if (hrs < 24) return `${hrs}h ago`;
+    const days = Math.floor(hrs / 24);
+    if (days < 7) return `${days}d ago`;
+    // Absolute format for older timestamps
+    const day = d.getDate();
+    const mon = d.toLocaleString("en", { month: "short" });
+    const time = d.toLocaleString("en", { hour: "numeric", minute: "2-digit", hour12: true });
+    return `${day} ${mon}, ${time}`;
+  }
+
+  function esc(s) {
+    if (typeof s !== "string") return "";
+    const d = document.createElement("div");
+    d.textContent = s;
+    return d.innerHTML;
+  }
+
+  return { init, setComments, setCollaborators, render };
+})();

--- a/Resources/web/collab-panel.js
+++ b/Resources/web/collab-panel.js
@@ -15,6 +15,11 @@ const CollabPanel = (() => {
   function init(user) {
     dbg('panel.init: ' + user);
     currentUser = user || "anonymous";
+    const badge = el(".collab-panel__identity");
+    if (badge) {
+      badge.textContent = "● " + currentUser;
+      badge.onclick = () => CollabBridge.requestIdentityChange();
+    }
     bindFilter();
     bindSort();
     bindResize();

--- a/Resources/web/reader.js
+++ b/Resources/web/reader.js
@@ -824,6 +824,7 @@
         mark.style.borderBottom = '2px solid ' + color;
         mark.style.cursor = 'pointer';
         mark.title = (ann.thread && ann.thread[0]) ? ann.thread[0].text || '' : '';
+        mark.onclick = () => postToSwift("collabScrollPanel", { annotationId: ann.id });
         try { range.surroundContents(mark); } catch(e) { /* crosses element boundary */ }
         break; // only highlight first occurrence
       }

--- a/Resources/web/reader.js
+++ b/Resources/web/reader.js
@@ -795,6 +795,41 @@
     }
   };
 
+  // Apply collab annotation highlights in the reader (called from Swift)
+  window.mindleApplyCollabHighlights = function (annotations) {
+    // Remove existing collab highlights
+    document.querySelectorAll('mark.collab-hl').forEach(m => {
+      const parent = m.parentNode;
+      parent.replaceChild(document.createTextNode(m.textContent), m);
+      parent.normalize();
+    });
+    if (!annotations || !annotations.length) return;
+
+    annotations.forEach(ann => {
+      if (!ann.anchor || !ann.anchor.text) return;
+      const searchText = ann.anchor.text;
+      const color = ann._color || '#6B4FBB';
+      const walker = document.createTreeWalker(doc, NodeFilter.SHOW_TEXT);
+      while (walker.nextNode()) {
+        const node = walker.currentNode;
+        const idx = node.textContent.indexOf(searchText);
+        if (idx === -1) continue;
+        const range = document.createRange();
+        range.setStart(node, idx);
+        range.setEnd(node, idx + searchText.length);
+        const mark = document.createElement('mark');
+        mark.className = 'collab-hl';
+        mark.dataset.collabId = ann.id;
+        mark.style.backgroundColor = color + '25';
+        mark.style.borderBottom = '2px solid ' + color;
+        mark.style.cursor = 'pointer';
+        mark.title = (ann.thread && ann.thread[0]) ? ann.thread[0].text || '' : '';
+        try { range.surroundContents(mark); } catch(e) { /* crosses element boundary */ }
+        break; // only highlight first occurrence
+      }
+    });
+  };
+
   let selTimer = null;
   document.addEventListener("selectionchange", () => {
     if (selTimer) clearTimeout(selTimer);

--- a/Resources/web/reader.js
+++ b/Resources/web/reader.js
@@ -776,6 +776,25 @@
     return captureSelection() || { text: "", prefix: "", suffix: "" };
   };
 
+  // Scroll to a text passage (called from collab panel anchor clicks)
+  window.mindleScrollToText = function (text) {
+    if (!text) return;
+    const walker = document.createTreeWalker(doc, NodeFilter.SHOW_TEXT);
+    let node;
+    while ((node = walker.nextNode())) {
+      if (node.textContent.indexOf(text) >= 0) {
+        const el = node.parentElement;
+        if (el) {
+          el.scrollIntoView({ behavior: "smooth", block: "center" });
+          const orig = el.style.backgroundColor;
+          el.style.backgroundColor = "rgba(74,144,217,0.3)";
+          setTimeout(() => { el.style.backgroundColor = orig; }, 1500);
+        }
+        return;
+      }
+    }
+  };
+
   let selTimer = null;
   document.addEventListener("selectionchange", () => {
     if (selTimer) clearTimeout(selTimer);
@@ -784,6 +803,17 @@
       const cap = captureSelection();
       postToSwift("selectionChanged", cap || { text: "", prefix: "", suffix: "" });
     }, 150);
+  });
+
+  // ⌘⇧K — add collab comment on current selection
+  document.addEventListener("keydown", (e) => {
+    if (e.metaKey && e.shiftKey && e.code === "KeyK") {
+      e.preventDefault();
+      const cap = captureSelection();
+      if (cap && cap.text) {
+        postToSwift("collabNewComment", cap);
+      }
+    }
   });
 
   doc.addEventListener("click", (ev) => {

--- a/Sources/Collab/CollabEngine.swift
+++ b/Sources/Collab/CollabEngine.swift
@@ -1,0 +1,104 @@
+// CollabEngine.swift — CRUD engine for the unified .collab.json sidecar.
+
+import Foundation
+import CryptoKit
+
+public final class CollabEngine {
+    public var document: CollabDocument = CollabDocument()
+    private var sidecarURL: URL?
+
+    public init() {}
+
+    /// Sidecar path: `<file>.md.collab.json`
+    public static func sidecarURL(for markdownURL: URL) -> URL {
+        markdownURL.appendingPathExtension("collab.json")
+    }
+
+    /// Loads existing sidecar or initializes fresh. Updates fileHash.
+    public func load(for markdownURL: URL) throws {
+        let url = Self.sidecarURL(for: markdownURL)
+        sidecarURL = url
+
+        if FileManager.default.fileExists(atPath: url.path) {
+            let data = try Data(contentsOf: url)
+            let decoder = JSONDecoder()
+            decoder.dateDecodingStrategy = .iso8601
+            document = try decoder.decode(CollabDocument.self, from: data)
+        } else {
+            document = CollabDocument()
+        }
+
+        let mdData = try Data(contentsOf: markdownURL)
+        document.fileHash = "sha256:" + SHA256.hash(data: mdData)
+            .map { String(format: "%02x", $0) }.joined()
+    }
+
+    /// Persists to disk atomically.
+    public func save() throws {
+        guard let url = sidecarURL else { return }
+        let encoder = JSONEncoder()
+        encoder.dateEncodingStrategy = .iso8601
+        encoder.outputFormatting = [.prettyPrinted, .sortedKeys]
+        let data = try encoder.encode(document)
+        try data.write(to: url, options: .atomic)
+    }
+
+    // MARK: - Annotations
+
+    /// Creates a new annotation with the first message as the body.
+    @discardableResult
+    public func addAnnotation(anchor: TextAnchor, author: String, text: String) -> CollabAnnotation {
+        let msg = ThreadMessage(id: UUID().uuidString, author: author, text: text)
+        let annotation = CollabAnnotation(
+            id: UUID().uuidString, anchor: anchor, author: author, thread: [msg]
+        )
+        document.annotations.append(annotation)
+        return annotation
+    }
+
+    /// Appends a reply to an annotation thread.
+    public func reply(to annotationID: String, author: String, text: String) {
+        guard let idx = document.annotations.firstIndex(where: { $0.id == annotationID }) else { return }
+        let msg = ThreadMessage(id: UUID().uuidString, author: author, text: text)
+        document.annotations[idx].thread.append(msg)
+    }
+
+    /// Resolves an annotation.
+    public func resolve(annotationID: String, by user: String) {
+        guard let idx = document.annotations.firstIndex(where: { $0.id == annotationID }) else { return }
+        document.annotations[idx].status = .resolved
+        document.annotations[idx].resolvedBy = user
+        document.annotations[idx].resolvedAt = Date()
+    }
+
+    /// Reopens a resolved annotation.
+    public func reopen(annotationID: String) {
+        guard let idx = document.annotations.firstIndex(where: { $0.id == annotationID }) else { return }
+        document.annotations[idx].status = .open
+        document.annotations[idx].resolvedBy = nil
+        document.annotations[idx].resolvedAt = nil
+    }
+
+    /// Assigns an annotation to a collaborator.
+    public func assign(annotationID: String, to assignee: String) {
+        guard let idx = document.annotations.firstIndex(where: { $0.id == annotationID }) else { return }
+        document.annotations[idx].assignee = assignee
+    }
+
+    /// Adds a label to an annotation.
+    public func addLabel(annotationID: String, label: String) {
+        guard let idx = document.annotations.firstIndex(where: { $0.id == annotationID }) else { return }
+        if !document.annotations[idx].labels.contains(label) {
+            document.annotations[idx].labels.append(label)
+        }
+    }
+
+    // MARK: - Collaborators
+
+    /// Registers a collaborator (idempotent — won't overwrite existing).
+    public func registerCollaborator(alias: String, collaborator: Collaborator) {
+        if document.collaborators[alias] == nil {
+            document.collaborators[alias] = collaborator
+        }
+    }
+}

--- a/Sources/Collab/CollabFileWatcher.swift
+++ b/Sources/Collab/CollabFileWatcher.swift
@@ -1,0 +1,93 @@
+import Foundation
+import Combine
+
+/// Watches a `.collab.json` sidecar file for external changes (e.g. OneDrive sync).
+/// On change: reloads, merges with in-memory state, and publishes the merged document.
+@MainActor
+public final class CollabFileWatcher {
+    private let engine: CollabEngine
+    private var sidecarURL: URL?
+    private var source: DispatchSourceFileSystemObject?
+    private var fileDescriptor: Int32 = -1
+    private var debounceWorkItem: DispatchWorkItem?
+
+    /// Published whenever the sidecar is updated externally and merged.
+    public let documentDidChange = PassthroughSubject<CollabDocument, Never>()
+
+    public init(engine: CollabEngine) {
+        self.engine = engine
+    }
+
+    deinit {
+        debounceWorkItem?.cancel()
+        source?.cancel()
+    }
+
+    /// Start watching the sidecar for the given markdown file.
+    public func watch(for markdownURL: URL) {
+        stop()
+        let url = CollabEngine.sidecarURL(for: markdownURL)
+        sidecarURL = url
+
+        // Ensure the file exists so we can open a descriptor
+        if !FileManager.default.fileExists(atPath: url.path) {
+            FileManager.default.createFile(atPath: url.path, contents: "{}".data(using: .utf8))
+        }
+
+        fileDescriptor = open(url.path, O_EVTONLY)
+        guard fileDescriptor >= 0 else { return }
+
+        let src = DispatchSource.makeFileSystemObjectSource(
+            fileDescriptor: fileDescriptor,
+            eventMask: [.write, .rename, .delete],
+            queue: .main
+        )
+
+        src.setEventHandler { [weak self] in
+            MainActor.assumeIsolated {
+                self?.scheduleReload()
+            }
+        }
+
+        src.setCancelHandler { [fd = fileDescriptor] in
+            close(fd)
+        }
+
+        source = src
+        src.resume()
+    }
+
+    public func stop() {
+        debounceWorkItem?.cancel()
+        debounceWorkItem = nil
+        source?.cancel()
+        source = nil
+        fileDescriptor = -1
+    }
+
+    // MARK: - Private
+
+    private func scheduleReload() {
+        debounceWorkItem?.cancel()
+        let work = DispatchWorkItem { [weak self] in
+            guard let self else { return }
+            self.reloadAndMerge()
+        }
+        debounceWorkItem = work
+        DispatchQueue.main.asyncAfter(deadline: .now() + 0.3, execute: work)
+    }
+
+    private func reloadAndMerge() {
+        guard let url = sidecarURL else { return }
+        guard let data = try? Data(contentsOf: url) else { return }
+
+        let decoder = JSONDecoder()
+        decoder.dateDecodingStrategy = .iso8601
+        guard let remote = try? decoder.decode(CollabDocument.self, from: data) else { return }
+
+        let result = MergeEngine.merge(local: engine.document, remote: remote)
+        engine.document = result.merged
+        try? engine.save()
+        documentDidChange.send(result.merged)
+    }
+}

--- a/Sources/Collab/CollabMCPExtensions.swift
+++ b/Sources/Collab/CollabMCPExtensions.swift
@@ -1,0 +1,91 @@
+// CollabMCPExtensions.swift — MCP tool definitions for the unified collab model.
+// These extend Mindle v2's base MCP tools with collaboration-aware operations.
+// Stubs until wired into the mindle-mcp binary's Unix socket protocol.
+
+import Foundation
+
+enum CollabMCPTool: String, CaseIterable {
+    // Inherited from Mindle v2
+    case listOpenFiles = "list_open_files"
+    case readFile = "read_file"
+    case getAnnotations = "get_annotations"
+    case clearAnnotation = "clear_annotation"
+    case waitForEvent = "wait_for_annotation_event"
+
+    // Collab extensions
+    case getCollabAnnotations = "get_collab_annotations"
+    case addAnnotation = "add_annotation"
+    case replyToAnnotation = "reply_to_annotation"
+    case resolveAnnotation = "resolve_annotation"
+    case assignAnnotation = "assign_annotation"
+    case getCollaborators = "get_collaborators"
+
+    var description: String {
+        switch self {
+        case .listOpenFiles: return "List files currently open"
+        case .readFile: return "Read file content"
+        case .getAnnotations: return "Get Mindle annotations (v2 native)"
+        case .clearAnnotation: return "Remove an annotation"
+        case .waitForEvent: return "Long-poll for annotation events"
+        case .getCollabAnnotations: return "Get collab annotations with status/assignee/labels"
+        case .addAnnotation: return "Add an annotation (human or agent)"
+        case .replyToAnnotation: return "Reply to an annotation thread"
+        case .resolveAnnotation: return "Resolve an annotation"
+        case .assignAnnotation: return "Assign an annotation to a collaborator"
+        case .getCollaborators: return "List collaborators for a document"
+        }
+    }
+}
+
+/// Handles collab MCP tool calls against the unified engine.
+struct CollabMCPHandler {
+    let engine: CollabEngine
+    let identity: IdentityManager
+
+    func handle(tool: CollabMCPTool, input: [String: Any]) -> [String: Any] {
+        switch tool {
+        case .getCollabAnnotations:
+            return ["count": engine.document.annotations.count]
+
+        case .addAnnotation:
+            guard let anchorText = input["anchor_text"] as? String,
+                  let text = input["text"] as? String else {
+                return ["error": "missing anchor_text or text"]
+            }
+            let author = (input["author"] as? String) ?? identity.alias
+            let anchor = TextAnchor(text: anchorText, prefix: "", suffix: "")
+            let ann = engine.addAnnotation(anchor: anchor, author: author, text: text)
+            return ["id": ann.id, "status": "created"]
+
+        case .replyToAnnotation:
+            guard let id = input["annotation_id"] as? String,
+                  let text = input["text"] as? String else {
+                return ["error": "missing annotation_id or text"]
+            }
+            let author = (input["author"] as? String) ?? identity.alias
+            engine.reply(to: id, author: author, text: text)
+            return ["status": "replied"]
+
+        case .resolveAnnotation:
+            guard let id = input["annotation_id"] as? String else {
+                return ["error": "missing annotation_id"]
+            }
+            engine.resolve(annotationID: id, by: identity.alias)
+            return ["status": "resolved"]
+
+        case .assignAnnotation:
+            guard let id = input["annotation_id"] as? String,
+                  let assignee = input["assignee"] as? String else {
+                return ["error": "missing annotation_id or assignee"]
+            }
+            engine.assign(annotationID: id, to: assignee)
+            return ["status": "assigned"]
+
+        case .getCollaborators:
+            return ["collaborators": Array(engine.document.collaborators.keys)]
+
+        case .listOpenFiles, .readFile, .getAnnotations, .clearAnnotation, .waitForEvent:
+            return ["error": "delegated to base mindle-mcp"]
+        }
+    }
+}

--- a/Sources/Collab/CollabTypes.swift
+++ b/Sources/Collab/CollabTypes.swift
@@ -1,0 +1,80 @@
+// CollabTypes.swift — Unified sidecar schema (v2.0) for humans AND agents.
+// A single .collab.json per markdown file stores all collaboration state:
+// collaborator registry, threaded annotations with status/assignee/labels.
+// Agents (via MCP) and humans (via UI) are just different collaborator types.
+
+import Foundation
+
+/// Root document stored in `<file>.md.collab.json`.
+public struct CollabDocument: Codable {
+    public var version: String = "2.0"
+    public var fileHash: String = ""
+    public var collaborators: [String: Collaborator] = [:]
+    public var annotations: [CollabAnnotation] = []
+    public init() {}
+}
+
+/// A participant — human or agent. Keyed by alias in the collaborators map.
+public struct Collaborator: Codable {
+    public var displayName: String
+    public var color: String
+    public var type: CollaboratorType
+    public var email: String?
+    public var mcp: Bool?  // true if this collaborator connects via MCP
+    public init(displayName: String, color: String, type: CollaboratorType = .human, email: String? = nil, mcp: Bool? = nil) {
+        self.displayName = displayName; self.color = color; self.type = type
+        self.email = email; self.mcp = mcp
+    }
+}
+
+public enum CollaboratorType: String, Codable {
+    case human
+    case agent
+}
+
+/// An annotation anchored to a text range, with a threaded discussion.
+public struct CollabAnnotation: Codable, Identifiable {
+    public var id: String
+    public var anchor: TextAnchor
+    public var author: String          // who created it
+    public var status: AnnotationStatus = .open
+    public var assignee: String?
+    public var labels: [String] = []
+    public var thread: [ThreadMessage] = []
+    public var createdAt: Date
+    public var resolvedBy: String?
+    public var resolvedAt: Date?
+    public init(id: String, anchor: TextAnchor, author: String, createdAt: Date = Date(),
+                status: AnnotationStatus = .open, assignee: String? = nil, labels: [String] = [],
+                thread: [ThreadMessage] = [], resolvedBy: String? = nil, resolvedAt: Date? = nil) {
+        self.id = id; self.anchor = anchor; self.author = author; self.createdAt = createdAt
+        self.status = status; self.assignee = assignee; self.labels = labels
+        self.thread = thread; self.resolvedBy = resolvedBy; self.resolvedAt = resolvedAt
+    }
+}
+
+public enum AnnotationStatus: String, Codable {
+    case open, resolved, wontfix
+}
+
+/// A single message in an annotation thread — from any collaborator type.
+public struct ThreadMessage: Codable, Identifiable {
+    public var id: String
+    public var author: String
+    public var text: String
+    public var createdAt: Date
+    public init(id: String, author: String, text: String, createdAt: Date = Date()) {
+        self.id = id; self.author = author; self.text = text; self.createdAt = createdAt
+    }
+}
+
+/// Content-addressable text anchor with surrounding context.
+public struct TextAnchor: Codable {
+    public var text: String
+    public var prefix: String
+    public var suffix: String
+    public var lineNumber: Int?
+    public init(text: String, prefix: String, suffix: String, lineNumber: Int? = nil) {
+        self.text = text; self.prefix = prefix; self.suffix = suffix; self.lineNumber = lineNumber
+    }
+}

--- a/Sources/Collab/CollabWebBridge.swift
+++ b/Sources/Collab/CollabWebBridge.swift
@@ -1,0 +1,110 @@
+// CollabWebBridge.swift — WKWebView ↔ Swift message bridge for the unified model.
+// Note: CollabPanelView.swift has its own inline coordinator for the actual panel.
+// This class provides the standalone bridge pattern for other use cases.
+
+import Foundation
+@preconcurrency import WebKit
+import Combine
+
+@MainActor
+public final class CollabWebBridge: NSObject, WKScriptMessageHandler {
+    private weak var webView: WKWebView?
+    private let engine: CollabEngine
+    private let identity: IdentityManager
+
+    public let didMutate = PassthroughSubject<Void, Never>()
+
+    public static let handlerNames = [
+        "collabReply", "collabResolve", "collabAssign",
+        "collabLabel", "collabNewComment", "collabRefresh"
+    ]
+
+    public init(engine: CollabEngine, identity: IdentityManager = .shared) {
+        self.engine = engine
+        self.identity = identity
+        super.init()
+    }
+
+    public func attach(to webView: WKWebView) {
+        self.webView = webView
+        let controller = webView.configuration.userContentController
+        for name in Self.handlerNames {
+            controller.add(self, name: name)
+        }
+    }
+
+    public func detach() {
+        guard let webView else { return }
+        let controller = webView.configuration.userContentController
+        for name in Self.handlerNames {
+            controller.removeScriptMessageHandler(forName: name)
+        }
+    }
+
+    public func pushAnnotations() {
+        guard let webView else { return }
+        let encoder = JSONEncoder()
+        encoder.dateEncodingStrategy = .iso8601
+        guard let data = try? encoder.encode(engine.document.annotations),
+              let json = String(data: data, encoding: .utf8) else { return }
+        webView.evaluateJavaScript("CollabBridge.receiveComments(\(json))")
+    }
+
+    public func pushTheme(_ theme: String) {
+        webView?.evaluateJavaScript("CollabBridge.receiveTheme('\(theme)')")
+    }
+
+    public func pushUser() {
+        webView?.evaluateJavaScript("CollabBridge.receiveUser('\(identity.alias)')")
+    }
+
+    // MARK: - WKScriptMessageHandler
+
+    nonisolated public func userContentController(
+        _ controller: WKUserContentController,
+        didReceive message: WKScriptMessage
+    ) {
+        let body = message.body
+        let name = message.name
+        Task { @MainActor in
+            guard let dict = body as? [String: Any] else { return }
+            self.handleMessage(name: name, body: dict)
+        }
+    }
+
+    private func handleMessage(name: String, body: [String: Any]) {
+        switch name {
+        case "collabReply":
+            guard let id = body["commentId"] as? String,
+                  let text = body["body"] as? String else { return }
+            engine.reply(to: id, author: identity.alias, text: text)
+
+        case "collabResolve":
+            guard let id = body["commentId"] as? String else { return }
+            engine.resolve(annotationID: id, by: identity.alias)
+
+        case "collabAssign":
+            guard let id = body["commentId"] as? String,
+                  let assignee = body["assignee"] as? String else { return }
+            engine.assign(annotationID: id, to: assignee)
+
+        case "collabLabel":
+            guard let id = body["commentId"] as? String,
+                  let label = body["label"] as? String else { return }
+            engine.addLabel(annotationID: id, label: label)
+
+        case "collabNewComment":
+            NotificationCenter.default.post(name: .collabNewCommentRequested, object: nil)
+
+        default:
+            break
+        }
+
+        didMutate.send()
+        pushAnnotations()
+    }
+}
+
+public extension Notification.Name {
+    static let collabNewCommentRequested = Notification.Name("collabNewCommentRequested")
+}

--- a/Sources/Collab/IdentityManager.swift
+++ b/Sources/Collab/IdentityManager.swift
@@ -1,0 +1,49 @@
+// IdentityManager.swift — Local user identity for collaboration.
+// Stores alias, display name, and color in UserDefaults. On first launch,
+// isFirstLaunch() returns true so the app can show a setup sheet.
+
+import Foundation
+
+/// Manages the current user's collaboration identity, persisted locally in UserDefaults.
+public final class IdentityManager {
+    public static let shared = IdentityManager()
+
+    private let defaults = UserDefaults.standard
+    private enum Keys {
+        static let alias = "markcollab.alias"
+        static let displayName = "markcollab.displayName"
+        static let color = "markcollab.color"
+    }
+
+    /// Preset color palette for the identity setup picker.
+    public static let defaultColors: [String] = [
+        "#4A90D9", "#E57373", "#81C784", "#FFB74D",
+        "#BA68C8", "#4DD0E1", "#F06292", "#AED581"
+    ]
+
+    /// True if the user hasn't set up their identity yet (no alias in UserDefaults).
+    public func isFirstLaunch() -> Bool {
+        defaults.string(forKey: Keys.alias) == nil
+    }
+
+    /// Returns the current user as a Collaborator struct.
+    public func whoAmI() -> Collaborator {
+        Collaborator(
+            displayName: defaults.string(forKey: Keys.displayName) ?? "Anonymous",
+            color: defaults.string(forKey: Keys.color) ?? Self.defaultColors[0],
+            email: nil
+        )
+    }
+
+    /// The user's short alias (used as author in comments/changes).
+    public var alias: String {
+        defaults.string(forKey: Keys.alias) ?? "anonymous"
+    }
+
+    /// Persists the user's chosen identity.
+    public func save(alias: String, displayName: String, color: String) {
+        defaults.set(alias, forKey: Keys.alias)
+        defaults.set(displayName, forKey: Keys.displayName)
+        defaults.set(color, forKey: Keys.color)
+    }
+}

--- a/Sources/Collab/MergeEngine.swift
+++ b/Sources/Collab/MergeEngine.swift
@@ -1,0 +1,55 @@
+// MergeEngine.swift — Conflict resolution for concurrent sidecar edits.
+// Strategy: union merge with last-writer-wins for status conflicts.
+
+import Foundation
+
+public final class MergeEngine {
+
+    public struct MergeResult {
+        public var merged: CollabDocument
+        public var conflicts: [Conflict]
+    }
+
+    public struct Conflict {
+        public var description: String
+        public var localValue: String
+        public var remoteValue: String
+    }
+
+    /// Union-merges remote into local. New annotations/messages appended; duplicates by ID skipped.
+    public static func merge(local: CollabDocument, remote: CollabDocument) -> MergeResult {
+        var merged = local
+        var conflicts: [Conflict] = []
+
+        // Merge collaborators (new from remote added)
+        for (key, collab) in remote.collaborators where merged.collaborators[key] == nil {
+            merged.collaborators[key] = collab
+        }
+
+        // Merge annotations by ID
+        let localIDs = Set(local.annotations.map(\.id))
+        for annotation in remote.annotations where !localIDs.contains(annotation.id) {
+            merged.annotations.append(annotation)
+        }
+
+        // Merge thread messages into shared annotations
+        for (idx, localAnn) in local.annotations.enumerated() {
+            if let remoteAnn = remote.annotations.first(where: { $0.id == localAnn.id }) {
+                let localMsgIDs = Set(localAnn.thread.map(\.id))
+                for msg in remoteAnn.thread where !localMsgIDs.contains(msg.id) {
+                    merged.annotations[idx].thread.append(msg)
+                }
+                // Detect status conflicts
+                if remoteAnn.status != localAnn.status {
+                    conflicts.append(Conflict(
+                        description: "Annotation \(localAnn.id) has conflicting status",
+                        localValue: localAnn.status.rawValue,
+                        remoteValue: remoteAnn.status.rawValue
+                    ))
+                }
+            }
+        }
+
+        return MergeResult(merged: merged, conflicts: conflicts)
+    }
+}

--- a/Sources/mindle/CollabPanelView.swift
+++ b/Sources/mindle/CollabPanelView.swift
@@ -13,7 +13,7 @@ struct CollabPanelView: NSViewRepresentable {
     func makeNSView(context: Context) -> WKWebView {
         let config = WKWebViewConfiguration()
         let userContent = WKUserContentController()
-        for name in ["collabReply", "collabResolve", "collabAssign", "collabLabel", "collabNewComment", "collabRefresh", "collabScrollToAnchor"] {
+        for name in ["collabReply", "collabResolve", "collabAssign", "collabLabel", "collabNewComment", "collabRefresh", "collabScrollToAnchor", "collabIdentityChange"] {
             userContent.add(context.coordinator, name: name)
         }
         config.userContentController = userContent
@@ -139,7 +139,6 @@ struct CollabPanelView: NSViewRepresentable {
                 }
 
             case "collabScrollToAnchor":
-                // Tell the reader WebView to scroll to this anchor text
                 guard let text = body["text"] as? String else { return }
                 let jsText = text.replacingOccurrences(of: "\\", with: "\\\\")
                     .replacingOccurrences(of: "'", with: "\\'")
@@ -149,6 +148,26 @@ struct CollabPanelView: NSViewRepresentable {
                     object: nil,
                     userInfo: ["js": "window.mindleScrollToText('\(jsText)')"]
                 )
+                return
+
+            case "collabIdentityChange":
+                let alert = NSAlert()
+                alert.messageText = "Set Identity"
+                alert.informativeText = "Enter your alias (used as author in comments)"
+                alert.addButton(withTitle: "Save")
+                alert.addButton(withTitle: "Cancel")
+                let input = NSTextField(frame: NSRect(x: 0, y: 0, width: 240, height: 24))
+                input.stringValue = IdentityManager.shared.alias
+                input.placeholderString = "e.g. ash"
+                alert.accessoryView = input
+                alert.window.initialFirstResponder = input
+                if alert.runModal() == .alertFirstButtonReturn {
+                    let alias = input.stringValue.trimmingCharacters(in: .whitespacesAndNewlines).lowercased()
+                    if alias.count >= 2 {
+                        IdentityManager.shared.save(alias: alias, displayName: alias, color: IdentityManager.shared.whoAmI().color)
+                        web?.evaluateJavaScript("CollabBridge.receiveUser('\(alias)');")
+                    }
+                }
                 return
 
             default:

--- a/Sources/mindle/CollabPanelView.swift
+++ b/Sources/mindle/CollabPanelView.swift
@@ -70,6 +70,12 @@ struct CollabPanelView: NSViewRepresentable {
             webView.evaluateJavaScript("CollabBridge.receiveTheme('\(store.theme.rawValue)');")
             pushAll()
             lastRevision = store.collabRevision
+
+            // Scroll panel to comment when reader highlight is clicked
+            NotificationCenter.default.addObserver(forName: Notification.Name("collabScrollPanelToComment"), object: nil, queue: .main) { [weak self] notif in
+                guard let id = notif.object as? String, let web = self?.web else { return }
+                web.evaluateJavaScript("CollabBridge.scrollPanelToComment('\(id)');")
+            }
         }
 
         // MARK: - WKScriptMessageHandler

--- a/Sources/mindle/CollabPanelView.swift
+++ b/Sources/mindle/CollabPanelView.swift
@@ -1,0 +1,164 @@
+// CollabPanelView.swift — NSViewRepresentable hosting the comment panel WKWebView.
+// Loads collab-panel.html and bridges user actions (reply, resolve, assign, etc.)
+// back to CollabEngine. Uses a polling approach via collabRevision because
+// SwiftUI's updateNSView doesn't reliably fire after NSAlert.runModal() blocks.
+// The Coordinator owns the WKWebView lifecycle and pushes data on revision changes.
+
+import SwiftUI
+import WebKit
+
+struct CollabPanelView: NSViewRepresentable {
+    @EnvironmentObject var store: DocumentStore
+
+    func makeNSView(context: Context) -> WKWebView {
+        let config = WKWebViewConfiguration()
+        let userContent = WKUserContentController()
+        for name in ["collabReply", "collabResolve", "collabAssign", "collabLabel", "collabNewComment", "collabRefresh", "collabScrollToAnchor"] {
+            userContent.add(context.coordinator, name: name)
+        }
+        config.userContentController = userContent
+        config.defaultWebpagePreferences.allowsContentJavaScript = true
+
+        let web = WKWebView(frame: .zero, configuration: config)
+        web.navigationDelegate = context.coordinator
+        web.setValue(false, forKey: "drawsBackground")
+        context.coordinator.web = web
+        context.coordinator.storeRef = store
+
+        if let html = Bundle.main.url(forResource: "collab-panel", withExtension: "html", subdirectory: "web") {
+            web.loadFileURL(html, allowingReadAccessTo: html.deletingLastPathComponent())
+        }
+        return web
+    }
+
+    func updateNSView(_ web: WKWebView, context: Context) {
+        let coord = context.coordinator
+        guard coord.loaded else { return }
+
+        // Trigger on collabRevision changes
+        let rev = store.collabRevision
+        if rev != coord.lastRevision {
+            coord.lastRevision = rev
+            coord.pushAll()
+        }
+    }
+
+    func makeCoordinator() -> Coordinator { Coordinator() }
+
+    final class Coordinator: NSObject, WKNavigationDelegate, WKScriptMessageHandler {
+        weak var web: WKWebView?
+        weak var storeRef: DocumentStore?
+        var loaded = false
+        var lastRevision = -1
+
+        func pushAll() {
+            guard let web, let store = storeRef else { return }
+            let collabs = store.collabCollaboratorsJSON
+            web.evaluateJavaScript("CollabPanel.setCollaborators(\(collabs));")
+            let json = store.collabCommentsJSON
+            web.evaluateJavaScript("CollabBridge.receiveComments(\(json));")
+        }
+
+        // MARK: - WKNavigationDelegate
+
+        func webView(_ webView: WKWebView, didFinish navigation: WKNavigation!) {
+            loaded = true
+            guard let store = storeRef else { return }
+
+            let alias = IdentityManager.shared.alias
+            webView.evaluateJavaScript("CollabBridge.receiveUser('\(alias)');")
+            webView.evaluateJavaScript("CollabBridge.receiveTheme('\(store.theme.rawValue)');")
+            pushAll()
+            lastRevision = store.collabRevision
+        }
+
+        // MARK: - WKScriptMessageHandler
+
+        func userContentController(_ controller: WKUserContentController, didReceive message: WKScriptMessage) {
+            guard let body = message.body as? [String: Any],
+                  let store = storeRef else { return }
+            let engine = store.collabEngine
+
+            switch message.name {
+            case "collabReply":
+                guard let cid = body["commentId"] as? String,
+                      let text = body["body"] as? String else { return }
+                engine.reply(to: cid, author: IdentityManager.shared.alias, text: text)
+
+            case "collabResolve":
+                guard let cid = body["commentId"] as? String else { return }
+                engine.resolve(annotationID: cid, by: IdentityManager.shared.alias)
+
+            case "collabAssign":
+                guard let cid = body["commentId"] as? String,
+                      let assignee = body["assignee"] as? String else { return }
+                engine.assign(annotationID: cid, to: assignee)
+
+            case "collabLabel":
+                guard let cid = body["commentId"] as? String,
+                      let label = body["label"] as? String else { return }
+                engine.addLabel(annotationID: cid, label: label)
+
+            case "collabNewComment":
+                // Snapshot selection NOW before focus change clears it
+                let selText = store.selectionText
+                let selPrefix = store.selectionPrefix
+                let selSuffix = store.selectionSuffix
+                guard !selText.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty else {
+                    NSSound.beep()
+                    return
+                }
+                let alert = NSAlert()
+                alert.messageText = "New Comment"
+                alert.informativeText = "On: \"\(selText.prefix(60))\""
+                alert.addButton(withTitle: "Add")
+                alert.addButton(withTitle: "Cancel")
+                let input = NSTextField(frame: NSRect(x: 0, y: 0, width: 300, height: 60))
+                input.placeholderString = "Your comment…"
+                alert.accessoryView = input
+                alert.window.initialFirstResponder = input
+                if alert.runModal() == .alertFirstButtonReturn {
+                    let body = input.stringValue.trimmingCharacters(in: .whitespacesAndNewlines)
+                    if !body.isEmpty {
+                        let anchor = TextAnchor(
+                            text: selText,
+                            prefix: String(selPrefix.suffix(48)),
+                            suffix: String(selSuffix.prefix(48))
+                        )
+                        engine.addAnnotation(anchor: anchor, author: IdentityManager.shared.alias, text: body)
+                        try? engine.save()
+                        store.collabRevision += 1
+                        pushAll()
+                    }
+                }
+                return
+
+            case "collabRefresh":
+                if let url = store.fileURL {
+                    try? engine.load(for: url)
+                }
+
+            case "collabScrollToAnchor":
+                // Tell the reader WebView to scroll to this anchor text
+                guard let text = body["text"] as? String else { return }
+                let jsText = text.replacingOccurrences(of: "\\", with: "\\\\")
+                    .replacingOccurrences(of: "'", with: "\\'")
+                    .replacingOccurrences(of: "\n", with: "\\n")
+                NotificationCenter.default.post(
+                    name: Notification.Name("collabScrollReader"),
+                    object: nil,
+                    userInfo: ["js": "window.mindleScrollToText('\(jsText)')"]
+                )
+                return
+
+            default:
+                return
+            }
+
+            // Save and refresh panel
+            try? engine.save()
+            store.collabRevision += 1
+            pushAll()
+        }
+    }
+}

--- a/Sources/mindle/ContentView.swift
+++ b/Sources/mindle/ContentView.swift
@@ -31,6 +31,10 @@ struct ContentView: View {
                             AnnotationsSidebar()
                                 .frame(minWidth: 280, idealWidth: 340, maxWidth: 460)
                         }
+                        if store.showCollabPanel {
+                            CollabPanelView()
+                                .frame(minWidth: 280, idealWidth: 340, maxWidth: 460)
+                        }
                     }
                 }
             }
@@ -117,6 +121,16 @@ struct ContentView: View {
                         .foregroundStyle(store.showAnnotations ? c.accent : c.muted)
                 }
                 .help("Toggle annotations (⌘⇧A)")
+
+                Button {
+                    withAnimation(.easeInOut(duration: 0.18)) {
+                        store.showCollabPanel.toggle()
+                    }
+                } label: {
+                    Image(systemName: "bubble.left.and.bubble.right")
+                        .foregroundStyle(store.showCollabPanel ? c.accent : c.muted)
+                }
+                .help("Toggle collab comments")
             }
         }
         .onDrop(of: [.fileURL], isTargeted: nil) { providers in

--- a/Sources/mindle/DocumentStore.swift
+++ b/Sources/mindle/DocumentStore.swift
@@ -2,6 +2,7 @@ import Foundation
 import SwiftUI
 import AppKit
 import UniformTypeIdentifiers
+import Combine
 
 enum ReaderTheme: String, CaseIterable, Codable {
     case light, sepia, dark
@@ -94,8 +95,8 @@ final class DocumentStore: ObservableObject {
 
     // Selection from the web view
     @Published private(set) var selectionText: String = ""
-    private var selectionPrefix: String = ""
-    private var selectionSuffix: String = ""
+    private(set) var selectionPrefix: String = ""
+    private(set) var selectionSuffix: String = ""
 
     @Published var focusedAnnotation: UUID? = nil
     /// When the user creates an annotation via ⌘⇧N, the annotation appears
@@ -127,6 +128,13 @@ final class DocumentStore: ObservableObject {
     // applyHighlight / applyNote with the fresh values.
     @Published var highlightRequestedAt: Date? = nil
     @Published var noteRequestedAt: Date? = nil
+
+    // MARK: - Collab
+    @Published var showCollabPanel: Bool = false
+    @Published var collabRevision: Int = 0
+    let collabEngine = CollabEngine()
+    private var collabWatcher: CollabFileWatcher?
+    private var collabWatcherSub: AnyCancellable?
 
     // FSEvents-based watcher on the active file. Replaced whenever the
     // active fileURL changes (open / tab activate / close).
@@ -193,6 +201,7 @@ final class DocumentStore: ObservableObject {
             self.lastSyncedText = text
             self.annotations = []
             self.loadSidecar()
+            self.loadCollabSidecar()
 
             // Capture the sidecar-loaded annotations into the tab snapshot.
             snapshotActiveTab()
@@ -905,5 +914,46 @@ final class DocumentStore: ObservableObject {
             out.append("")
         }
         return out.joined(separator: "\n")
+    }
+
+    // MARK: - Collab Sidecar
+
+    func loadCollabSidecar() {
+        guard let url = fileURL else { return }
+        try? collabEngine.load(for: url)
+        collabWatcher?.stop()
+        collabWatcher = CollabFileWatcher(engine: collabEngine)
+        collabWatcher?.watch(for: url)
+        collabWatcherSub = collabWatcher?.documentDidChange
+            .receive(on: RunLoop.main)
+            .sink { [weak self] _ in self?.collabRevision += 1 }
+    }
+
+    var collabCommentsJSON: String {
+        let encoder = JSONEncoder()
+        encoder.dateEncodingStrategy = .iso8601
+        guard let data = try? encoder.encode(collabEngine.document.annotations),
+              let json = String(data: data, encoding: .utf8) else { return "[]" }
+        return json
+    }
+
+    var collabCollaboratorsJSON: String {
+        let encoder = JSONEncoder()
+        guard let data = try? encoder.encode(collabEngine.document.collaborators),
+              let json = String(data: data, encoding: .utf8) else { return "{}" }
+        return json
+    }
+
+    func addCollabComment(body: String) {
+        guard hasSelection else { NSSound.beep(); return }
+        let anchor = TextAnchor(
+            text: selectionText,
+            prefix: String(selectionPrefix.suffix(48)),
+            suffix: String(selectionSuffix.prefix(48))
+        )
+        collabEngine.addAnnotation(anchor: anchor, author: IdentityManager.shared.alias, text: body)
+        try? collabEngine.save()
+        showCollabPanel = true
+        collabRevision += 1
     }
 }

--- a/Sources/mindle/IdentitySetupView.swift
+++ b/Sources/mindle/IdentitySetupView.swift
@@ -1,0 +1,61 @@
+import SwiftUI
+
+struct IdentitySetupView: View {
+    @Environment(\.dismiss) var dismiss
+    @State private var alias: String = ""
+    @State private var displayName: String = ""
+    @State private var selectedColor: String = "#4A90D9"
+
+    let colorPresets = IdentityManager.defaultColors
+
+    var body: some View {
+        VStack(spacing: 24) {
+            Text("Welcome to MarkCollab")
+                .font(.title2).bold()
+            Text("Set up your identity for collaboration")
+                .foregroundColor(.secondary)
+
+            TextField("Alias (e.g. ash)", text: $alias)
+                .textFieldStyle(.roundedBorder)
+            TextField("Display Name (e.g. Ashish Naik)", text: $displayName)
+                .textFieldStyle(.roundedBorder)
+
+            HStack(spacing: 12) {
+                ForEach(colorPresets, id: \.self) { color in
+                    Circle()
+                        .fill(Color(hex: color))
+                        .frame(width: 32, height: 32)
+                        .overlay(Circle().stroke(selectedColor == color ? Color.primary : Color.clear, lineWidth: 2))
+                        .onTapGesture { selectedColor = color }
+                }
+            }
+
+            Button("Get Started") {
+                IdentityManager.shared.save(
+                    alias: alias.lowercased().trimmingCharacters(in: .whitespaces),
+                    displayName: displayName,
+                    color: selectedColor
+                )
+                dismiss()
+            }
+            .disabled(alias.count < 3 || displayName.isEmpty)
+            .buttonStyle(.borderedProminent)
+        }
+        .padding(32)
+        .frame(width: 420)
+    }
+}
+
+// MARK: - Color hex extension
+
+extension Color {
+    init(hex: String) {
+        let hex = hex.trimmingCharacters(in: CharacterSet(charactersIn: "#"))
+        var int: UInt64 = 0
+        Scanner(string: hex).scanHexInt64(&int)
+        let r = Double((int >> 16) & 0xFF) / 255.0
+        let g = Double((int >> 8) & 0xFF) / 255.0
+        let b = Double(int & 0xFF) / 255.0
+        self.init(red: r, green: g, blue: b)
+    }
+}

--- a/Sources/mindle/MCPServer.swift
+++ b/Sources/mindle/MCPServer.swift
@@ -282,6 +282,57 @@ final class MCPServer {
                 "gap": result.gap
             ]
 
+        // MARK: - Collab ops
+
+        case "get_collab_annotations":
+            guard let path = request["path"] as? String else {
+                return ["ok": false, "error": "missing 'path'"]
+            }
+            let result: [String: Any] = await MainActor.run {
+                let url = URL(fileURLWithPath: path)
+                let engine = CollabEngine()
+                guard (try? engine.load(for: url)) != nil else {
+                    return ["ok": false, "error": "no collab sidecar for \(path)"]
+                }
+                let encoder = JSONEncoder()
+                encoder.dateEncodingStrategy = .iso8601
+                let data = (try? encoder.encode(engine.document)) ?? Data()
+                let json = (try? JSONSerialization.jsonObject(with: data)) as? [String: Any] ?? [:]
+                return ["ok": true, "document": json]
+            }
+            return result
+
+        case "collab_reply":
+            guard let path = request["path"] as? String,
+                  let annID = request["annotation_id"] as? String,
+                  let text = request["text"] as? String else {
+                return ["ok": false, "error": "missing path, annotation_id, or text"]
+            }
+            let author = (request["author"] as? String) ?? "agent"
+            let success: Bool = await MainActor.run {
+                let url = URL(fileURLWithPath: path)
+                let engine = CollabEngine()
+                guard (try? engine.load(for: url)) != nil else { return false }
+                engine.reply(to: annID, author: author, text: text)
+                return (try? engine.save()) != nil
+            }
+            return success ? ["ok": true] : ["ok": false, "error": "failed to reply"]
+
+        case "collab_resolve":
+            guard let path = request["path"] as? String,
+                  let annID = request["annotation_id"] as? String else {
+                return ["ok": false, "error": "missing path or annotation_id"]
+            }
+            let author = (request["author"] as? String) ?? "agent"
+            let success: Bool = await MainActor.run {
+                let url = URL(fileURLWithPath: path)
+                let engine = CollabEngine()
+                guard (try? engine.load(for: url)) != nil else { return false }
+                engine.resolve(annotationID: annID, by: author)
+                return (try? engine.save()) != nil
+            }
+            return success ? ["ok": true] : ["ok": false, "error": "failed to resolve"]
+
         default:
             return ["ok": false, "error": "unknown op: \(op)"]
         }

--- a/Sources/mindle/WebReaderView.swift
+++ b/Sources/mindle/WebReaderView.swift
@@ -16,6 +16,7 @@ struct WebReaderView: NSViewRepresentable {
         userContent.add(context.coordinator, name: "diffSetCurrent")
         userContent.add(context.coordinator, name: "diffAcceptAll")
         userContent.add(context.coordinator, name: "diffRejectAll")
+        userContent.add(context.coordinator, name: "collabNewComment")
         config.userContentController = userContent
         config.setURLSchemeHandler(ImageSchemeHandler(), forURLScheme: ImageSchemeHandler.scheme)
         config.defaultWebpagePreferences.allowsContentJavaScript = true
@@ -267,6 +268,13 @@ struct WebReaderView: NSViewRepresentable {
             DispatchQueue.main.async {
                 self.parent.store.objectWillChange.send()
             }
+
+            // Listen for scroll-to-anchor requests from the collab panel
+            NotificationCenter.default.addObserver(forName: Notification.Name("collabScrollReader"), object: nil, queue: .main) { [weak self] note in
+                guard let js = note.userInfo?["js"] as? String,
+                      let web = self?.web else { return }
+                web.evaluateJavaScript(js)
+            }
         }
 
         func webView(_ webView: WKWebView, decidePolicyFor action: WKNavigationAction,
@@ -337,6 +345,39 @@ struct WebReaderView: NSViewRepresentable {
             case "diffRejectAll":
                 Task { @MainActor in
                     self.parent.store.rejectAllChanges()
+                }
+
+            case "collabNewComment":
+                guard let body = message.body as? [String: Any],
+                      let text = body["text"] as? String, !text.isEmpty else { return }
+                let prefix = (body["prefix"] as? String) ?? ""
+                let suffix = (body["suffix"] as? String) ?? ""
+                Task { @MainActor in
+                    let store = self.parent.store
+                    store.updateSelection(text: text, prefix: prefix, suffix: suffix)
+                    store.showCollabPanel = true
+                    let alert = NSAlert()
+                    alert.messageText = "New Comment"
+                    alert.informativeText = "On: \"\(text.prefix(60))\""
+                    alert.addButton(withTitle: "Add")
+                    alert.addButton(withTitle: "Cancel")
+                    let input = NSTextField(frame: NSRect(x: 0, y: 0, width: 300, height: 60))
+                    input.placeholderString = "Your comment…"
+                    alert.accessoryView = input
+                    alert.window.initialFirstResponder = input
+                    if alert.runModal() == .alertFirstButtonReturn {
+                        let comment = input.stringValue.trimmingCharacters(in: .whitespacesAndNewlines)
+                        if !comment.isEmpty {
+                            let anchor = TextAnchor(
+                                text: text,
+                                prefix: String(prefix.suffix(48)),
+                                suffix: String(suffix.prefix(48))
+                            )
+                            store.collabEngine.addAnnotation(anchor: anchor, author: IdentityManager.shared.alias, text: comment)
+                            try? store.collabEngine.save()
+                            store.collabRevision += 1
+                        }
+                    }
                 }
 
             default: break

--- a/Sources/mindle/WebReaderView.swift
+++ b/Sources/mindle/WebReaderView.swift
@@ -17,6 +17,7 @@ struct WebReaderView: NSViewRepresentable {
         userContent.add(context.coordinator, name: "diffAcceptAll")
         userContent.add(context.coordinator, name: "diffRejectAll")
         userContent.add(context.coordinator, name: "collabNewComment")
+        userContent.add(context.coordinator, name: "collabScrollPanel")
         config.userContentController = userContent
         config.setURLSchemeHandler(ImageSchemeHandler(), forURLScheme: ImageSchemeHandler.scheme)
         config.defaultWebpagePreferences.allowsContentJavaScript = true
@@ -353,6 +354,17 @@ struct WebReaderView: NSViewRepresentable {
             case "diffRejectAll":
                 Task { @MainActor in
                     self.parent.store.rejectAllChanges()
+                }
+
+            case "collabScrollPanel":
+                guard let body = message.body as? [String: Any],
+                      let annotationId = body["annotationId"] as? String else { return }
+                Task { @MainActor in
+                    self.parent.store.showCollabPanel = true
+                    NotificationCenter.default.post(
+                        name: Notification.Name("collabScrollPanelToComment"),
+                        object: annotationId
+                    )
                 }
 
             case "collabNewComment":

--- a/Sources/mindle/WebReaderView.swift
+++ b/Sources/mindle/WebReaderView.swift
@@ -89,6 +89,13 @@ struct WebReaderView: NSViewRepresentable {
             }
         }
 
+        // Push collab highlights to reader
+        if store.collabRevision != coord.lastCollabRevision {
+            coord.lastCollabRevision = store.collabRevision
+            let collabJSON = store.collabCommentsJSON
+            web.evaluateJavaScript("window.mindleApplyCollabHighlights(\(collabJSON));")
+        }
+
         if let id = store.focusedAnnotation, id != coord.lastFocusID {
             coord.lastFocusID = id
             web.evaluateJavaScript("window.mindleFocusAnnotation(\(jsString(id.uuidString)));")
@@ -151,6 +158,7 @@ struct WebReaderView: NSViewRepresentable {
         var lastPDFExportAt: Date?
         var lastHighlightAt: Date?
         var lastNoteAt: Date?
+        var lastCollabRevision: Int = -1
 
         init(_ p: WebReaderView) { parent = p }
 

--- a/build.sh
+++ b/build.sh
@@ -48,8 +48,9 @@ swiftc -O \
   -target arm64-apple-macos14.0 \
   -parse-as-library \
   -F Frameworks \
-  -framework SwiftUI -framework AppKit -framework Foundation -framework UniformTypeIdentifiers -framework WebKit -framework PDFKit -framework Sparkle \
+  -framework SwiftUI -framework AppKit -framework Foundation -framework UniformTypeIdentifiers -framework WebKit -framework PDFKit -framework Sparkle -framework CryptoKit \
   -Xlinker -rpath -Xlinker "@executable_path/../Frameworks" \
+  Sources/Collab/*.swift \
   Sources/mindle/*.swift \
   -o "$BIN"
 

--- a/docs/collab-guide.md
+++ b/docs/collab-guide.md
@@ -1,0 +1,56 @@
+# Collab Guide
+
+How to use MarkCollab's team collaboration features.
+
+## Getting Started
+
+1. Build: `./build.sh`
+2. Open a markdown file: `open -a build/Mindle.app file.md`
+3. Click the 💬 button in the toolbar to open the comment panel
+4. Set your identity by clicking `● anonymous` in the panel header
+
+## Adding Comments
+
+1. Select text in the reader pane
+2. Click `+` in the panel header (or press ⌘⇧K)
+3. Type your comment in the dialog and click "Add"
+
+The comment appears in the panel and the anchored text is highlighted in the reader.
+
+## Replying & Resolving
+
+- **Reply:** Type in the reply box at the bottom of any comment card and click "Reply"
+- **Resolve:** Click "Resolve" to mark a thread as addressed
+- **Reopen:** Click "Reopen" on a resolved comment to continue discussion
+
+## Assign & Labels
+
+- **Assign:** Click "Assign ▾" → select a collaborator from the dropdown
+- **Labels:** Click "Labels ▾" → pick from: question, blocker, nit, todo, suggestion
+
+## Inline Highlights
+
+When the collab panel is open, commented passages are highlighted in the reader pane with the author's color (as an underline). Click any highlight to jump to that comment in the panel.
+
+New comments appear as highlights immediately after creation.
+
+## Sorting & Filtering
+
+- **Filter:** All / Open / Resolved / My Assignments
+- **Sort:** Newest first / Oldest first / Doc position
+
+## Refresh
+
+Click ↻ to reload the sidecar from disk — useful after a collaborator pushes changes via OneDrive or shared drive sync.
+
+## For AI Agents (MCP)
+
+Agents connect via the `mindle-mcp` binary and can use these collab ops:
+
+- `get_collab_annotations` — read the full `.collab.json` for a file
+- `collab_reply` — reply to a thread (author defaults to "agent")
+- `collab_resolve` — resolve an annotation
+
+## Sidecar Format
+
+Collaboration data lives in `<file>.md.collab.json` alongside the markdown. Removing this file removes all collab metadata without affecting the document.

--- a/docs/releases/v2.2.0-collab.md
+++ b/docs/releases/v2.2.0-collab.md
@@ -1,0 +1,71 @@
+## v2.2.0-collab — 🤝 Team Collaboration
+
+> 🧪 Feature branch. Built on top of v2.1.0-rc3. Intended for upstream contribution.
+
+Mindle becomes a collaboration surface for teams. Comments, replies, assignments, and labels — all stored in a unified `.collab.json` sidecar alongside your markdown. Agents and humans participate equally in the same annotation threads.
+
+### What's new
+
+**Unified `.collab.json` sidecar.** A single file per document stores all collaboration metadata: threaded comments, assignments, labels, and participant identities. Human collaborators and AI agents are treated identically — both appear as entries in the `collaborators` registry with author-keyed threads. The schema supports `type: "human"` and `type: "agent"` collaborators, with optional `mcp: true` for MCP-connected agents.
+
+**Comment panel (💬 toolbar button).** A dedicated sidebar — separate from Mindle's personal annotations — for team conversations. Threaded replies with author dots and relative timestamps, resolve/reopen toggle, assign to collaborator, label with presets (question, blocker, nit, todo, suggestion). Pinned header, scrollable list, pinned debug footer.
+
+**Add comment on selection.** Select text in the reader → click `+` in the panel header or press ⌘⇧K → dialog captures your comment anchored to the passage. The selection is snapshotted at keydown time via `captureSelection()`, bypassing the debounced `selectionchange` cache.
+
+**Assign & Label dropdowns.** Proper dropdown menus instead of browser prompts. Assign shows collaborators from the sidecar registry; Labels offers five presets. Falls back to text prompt if the collaborator list is empty.
+
+**Sort toggle.** Comments can be sorted by newest first, oldest first, or document position (approximated by anchor prefix).
+
+**Scroll-to-anchor.** Click the quoted anchor text on any comment card → the reader pane scrolls to that passage with a brief highlight flash. Implemented via `mindleScrollToText()` in reader.js, triggered by a `collabScrollReader` notification from the panel coordinator.
+
+**Identity editor.** Clickable `● alias` badge in the panel header. Click to set your alias (min 2 chars). Persisted in UserDefaults via `IdentityManager`. No first-launch sheet required — identity is set inline.
+
+**Refresh button (↻).** Reloads the sidecar from disk — useful after a collaborator pushes changes via shared drive sync.
+
+**Debug toggle (🐛).** Shows a live log of panel events for troubleshooting. Hidden by default.
+
+### Architecture
+
+```
+.md file ←→ CollabEngine ←→ .md.collab.json (sidecar)
+                ↕
+         CollabPanelView (WKWebView in HSplitView)
+                ↕
+    collab-panel.js ↔ collab-bridge.js ↔ webkit.messageHandlers
+```
+
+The collab layer is additive — removing `Sources/Collab/` and the panel view reverts to stock Mindle. The `.collab.json` sidecar is independent of Mindle's `.mindle.json` annotation sidecar.
+
+### Files added
+
+```
+Sources/Collab/
+  CollabTypes.swift          — unified schema (CollabDocument, CollabAnnotation, ThreadMessage)
+  CollabEngine.swift         — CRUD for .collab.json sidecars
+  MergeEngine.swift          — union + LWW conflict resolution
+  IdentityManager.swift      — local user identity (UserDefaults)
+  CollabFileWatcher.swift    — DispatchSource watcher with 300ms debounce
+  CollabWebBridge.swift      — WKScriptMessageHandler + Notification.Name
+  CollabMCPExtensions.swift  — MCP tool schemas for agent participation
+
+Sources/mindle/
+  CollabPanelView.swift      — NSViewRepresentable + Coordinator
+  IdentitySetupView.swift    — SwiftUI sheet (unused, identity set inline)
+
+Resources/web/
+  collab-panel.html/css/js   — panel UI
+  collab-bridge.js           — JS↔Swift bridge
+  collab-highlights.js       — inline highlight overlays (scaffold)
+```
+
+### Files modified
+
+- `DocumentStore.swift` — collab properties, `loadCollabSidecar()`, `addCollabComment()`
+- `ContentView.swift` — `CollabPanelView` in HSplitView + 💬 toolbar button
+- `WebReaderView.swift` — `collabNewComment` handler + scroll notification observer
+- `reader.js` — `mindleScrollToText()` + ⌘⇧K keydown listener
+- `build.sh` — `Sources/Collab/*.swift` + CryptoKit framework
+
+---
+
+**Full diff:** `upstream/main..collab/v3-upstream`

--- a/docs/releases/v2.2.0-collab.md
+++ b/docs/releases/v2.2.0-collab.md
@@ -18,6 +18,10 @@ Mindle becomes a collaboration surface for teams. Comments, replies, assignments
 
 **Scroll-to-anchor.** Click the quoted anchor text on any comment card → the reader pane scrolls to that passage with a brief highlight flash. Implemented via `mindleScrollToText()` in reader.js, triggered by a `collabScrollReader` notification from the panel coordinator.
 
+**Inline comment highlights in reader pane.** Anchored passages are underlined in the comment author's color. Click a highlight → panel opens and scrolls to that thread. Highlights refresh immediately when comments are added or removed.
+
+**MCP tools wired.** `get_collab_annotations`, `collab_reply`, `collab_resolve` are registered in the MCP server — AI agents can participate in collab threads via the standard MCP protocol. Ops are stateless: load sidecar → mutate → save.
+
 **Identity editor.** Clickable `● alias` badge in the panel header. Click to set your alias (min 2 chars). Persisted in UserDefaults via `IdentityManager`. No first-launch sheet required — identity is set inline.
 
 **Refresh button (↻).** Reloads the sidecar from disk — useful after a collaborator pushes changes via shared drive sync.
@@ -62,9 +66,14 @@ Resources/web/
 
 - `DocumentStore.swift` — collab properties, `loadCollabSidecar()`, `addCollabComment()`
 - `ContentView.swift` — `CollabPanelView` in HSplitView + 💬 toolbar button
-- `WebReaderView.swift` — `collabNewComment` handler + scroll notification observer
-- `reader.js` — `mindleScrollToText()` + ⌘⇧K keydown listener
+- `WebReaderView.swift` — `collabNewComment` + `collabScrollPanel` handlers + scroll observer
+- `MCPServer.swift` — `get_collab_annotations`, `collab_reply`, `collab_resolve` ops
+- `reader.js` — `mindleScrollToText()`, `mindleApplyCollabHighlights()`, ⌘⇧K listener
 - `build.sh` — `Sources/Collab/*.swift` + CryptoKit framework
+
+### Known limitations
+
+- ⌘⇧K shortcut unreliable (WebView focus issue) — `+` button works reliably
 
 ---
 

--- a/sample.md.collab.json
+++ b/sample.md.collab.json
@@ -302,6 +302,28 @@
           "text" : "ewfef"
         }
       ]
+    },
+    {
+      "anchor" : {
+        "prefix" : " to your file. Nothing leaves your machine.\n\nCod",
+        "suffix" : "\nfunc greet(_ name: String) -> String {\n    \"Hel",
+        "text" : "e looks decent too"
+      },
+      "author" : "ash",
+      "createdAt" : "2026-05-13T05:51:40Z",
+      "id" : "8EE9CAEF-1F7D-4CD6-AA70-7CB0C32BC620",
+      "labels" : [
+
+      ],
+      "status" : "open",
+      "thread" : [
+        {
+          "author" : "ash",
+          "createdAt" : "2026-05-13T05:51:40Z",
+          "id" : "26C91A5F-E646-479B-AD55-A84718259E6C",
+          "text" : "jbkjvkv"
+        }
+      ]
     }
   ],
   "collaborators" : {

--- a/sample.md.collab.json
+++ b/sample.md.collab.json
@@ -280,6 +280,28 @@
           "text" : "My name is ash"
         }
       ]
+    },
+    {
+      "anchor" : {
+        "prefix" : "en a2+b2=c2a^2 + b^2 = c^2a2+b2=c2 holds, we hav",
+        "suffix" : "Display:\n∑i=1ni=n(n+1)2\\sum_{i=1}^{n} i = \\frac{",
+        "text" : "e a right triangle. Greek: α+β=γ\\alpha + \\beta = \\gammaα+β=γ.\n"
+      },
+      "author" : "ash",
+      "createdAt" : "2026-05-13T05:35:54Z",
+      "id" : "F069E6B6-7B85-4D5C-B5CC-490078D291C2",
+      "labels" : [
+
+      ],
+      "status" : "open",
+      "thread" : [
+        {
+          "author" : "ash",
+          "createdAt" : "2026-05-13T05:35:54Z",
+          "id" : "4C6818C4-8533-4891-B4B5-97BEAC992DB9",
+          "text" : "ewfef"
+        }
+      ]
     }
   ],
   "collaborators" : {

--- a/sample.md.collab.json
+++ b/sample.md.collab.json
@@ -1,0 +1,284 @@
+{
+  "annotations" : [
+    {
+      "anchor" : {
+        "prefix" : "# Mindle\n\n",
+        "suffix" : ".\n\n## What it does",
+        "text" : "A quiet place to read Markdown"
+      },
+      "assignee" : "priya",
+      "author" : "ash",
+      "createdAt" : "2026-05-12T18:00:00Z",
+      "id" : "a001",
+      "labels" : [
+        "question"
+      ],
+      "status" : "open",
+      "thread" : [
+        {
+          "author" : "ash",
+          "createdAt" : "2026-05-12T18:00:00Z",
+          "id" : "m001",
+          "text" : "Should we update this tagline now that it's collaborative?"
+        },
+        {
+          "author" : "claude",
+          "createdAt" : "2026-05-12T18:01:00Z",
+          "id" : "m002",
+          "text" : "Consider something like 'Collaborative markdown for teams' — keeps it short."
+        },
+        {
+          "author" : "priya",
+          "createdAt" : "2026-05-12T18:05:00Z",
+          "id" : "m003",
+          "text" : "Agreed with Claude. Let's update after Phase 1."
+        }
+      ]
+    },
+    {
+      "anchor" : {
+        "prefix" : "sidecar next to your file. ",
+        "suffix" : ".\n\n## Code",
+        "text" : "Nothing leaves your machine"
+      },
+      "author" : "priya",
+      "createdAt" : "2026-05-12T18:10:00Z",
+      "id" : "a002",
+      "labels" : [
+        "blocker"
+      ],
+      "status" : "open",
+      "thread" : [
+        {
+          "author" : "priya",
+          "createdAt" : "2026-05-12T18:10:00Z",
+          "id" : "m004",
+          "text" : "This claim needs updating — with OneDrive sync, data does leave the machine."
+        }
+      ]
+    },
+    {
+      "anchor" : {
+        "prefix" : "r style layout. You can:\n\nHighlight any paragrap",
+        "suffix" : "\nAttach a note to any block\nToggle between light",
+        "text" : "h with one click"
+      },
+      "author" : "anonymous",
+      "createdAt" : "2026-05-12T20:46:58Z",
+      "id" : "394C88C3-CB55-4481-9CB8-DD89BB1CB914",
+      "labels" : [
+
+      ],
+      "status" : "open",
+      "thread" : [
+        {
+          "author" : "anonymous",
+          "createdAt" : "2026-05-12T20:46:58Z",
+          "id" : "B7C9EDE0-C06E-4AB2-B0D0-D3251FC6D74C",
+          "text" : "hjhjbjk"
+        }
+      ]
+    },
+    {
+      "anchor" : {
+        "prefix" : "ader style layout. You can:\n\nHighlight any parag",
+        "suffix" : "\nAttach a note to any block\nToggle between light",
+        "text" : "raph with one click"
+      },
+      "author" : "anonymous",
+      "createdAt" : "2026-05-12T20:47:08Z",
+      "id" : "A8C7F23C-ACE5-46EA-BD15-E87FD6BE8150",
+      "labels" : [
+
+      ],
+      "status" : "open",
+      "thread" : [
+        {
+          "author" : "anonymous",
+          "createdAt" : "2026-05-12T20:47:08Z",
+          "id" : "4C90D39D-D1A1-40B0-9171-EE955B2F6759",
+          "text" : "lllll"
+        }
+      ]
+    },
+    {
+      "anchor" : {
+        "prefix" : "f, e-reader style layout. You can:\n\nHighlight an",
+        "suffix" : "\nPop out an annotations sidebar with ⌘⇧A\n\n\nAnnot",
+        "text" : "y paragraph with one click\nAttach a note to any block\nToggle between light, sepia, and dark themes\nZoom the type with ⌘+ and ⌘-"
+      },
+      "author" : "anonymous",
+      "createdAt" : "2026-05-12T20:47:26Z",
+      "id" : "C5CE34EF-0DAE-4610-8046-14E93460ECF5",
+      "labels" : [
+
+      ],
+      "status" : "open",
+      "thread" : [
+        {
+          "author" : "anonymous",
+          "createdAt" : "2026-05-12T20:47:26Z",
+          "id" : "3B8A90E1-2BF2-4172-ACEE-CF4EAC1E3F06",
+          "text" : "fefefefe"
+        }
+      ]
+    },
+    {
+      "anchor" : {
+        "prefix" : "le\nA quiet place to read Markdown.\nWhat it does\n",
+        "suffix" : "\nAttach a note to any block\nToggle between light",
+        "text" : "Open any .md file and read it in a clean, serif, e-reader style layout. You can:\n\nHighlight any paragraph with one click"
+      },
+      "author" : "anonymous",
+      "createdAt" : "2026-05-12T20:53:05Z",
+      "id" : "0CAE536F-E5BA-4159-9519-D3DF6464B57B",
+      "labels" : [
+
+      ],
+      "status" : "open",
+      "thread" : [
+        {
+          "author" : "anonymous",
+          "createdAt" : "2026-05-12T20:53:05Z",
+          "id" : "FC26FDF6-7616-4262-9F35-96744ED798F4",
+          "text" : "efefef"
+        }
+      ]
+    },
+    {
+      "anchor" : {
+        "prefix" : "le\nA quiet place to read Markdown.\nWhat it does\n",
+        "suffix" : "\nAttach a note to any block\nToggle between light",
+        "text" : "Open any .md file and read it in a clean, serif, e-reader style layout. You can:\n\nHighlight any paragraph with one click"
+      },
+      "author" : "anonymous",
+      "createdAt" : "2026-05-12T20:53:12Z",
+      "id" : "EAD31E01-AF4F-4FEA-B6EC-EA1D0CAD9B80",
+      "labels" : [
+
+      ],
+      "status" : "open",
+      "thread" : [
+        {
+          "author" : "anonymous",
+          "createdAt" : "2026-05-12T20:53:12Z",
+          "id" : "6235AE9B-4F5D-4846-8E7B-F33E170CA911",
+          "text" : "eeeee"
+        }
+      ]
+    },
+    {
+      "anchor" : {
+        "prefix" : "ou can:\n\nHighlight any paragraph with one click\n",
+        "suffix" : "\nToggle between light, sepia, and dark themes\nZo",
+        "text" : "Attach a note to any block"
+      },
+      "author" : "anonymous",
+      "createdAt" : "2026-05-12T20:54:57Z",
+      "id" : "35B024CD-96DA-4CA6-AEC1-2A352F5641F6",
+      "labels" : [
+
+      ],
+      "status" : "open",
+      "thread" : [
+        {
+          "author" : "anonymous",
+          "createdAt" : "2026-05-12T20:54:57Z",
+          "id" : "247F53EA-0E76-44DF-AD41-8CDA7DBFE69D",
+          "text" : "HelloAsh"
+        }
+      ]
+    },
+    {
+      "anchor" : {
+        "prefix" : " clean, serif, e-reader style layout. You can:\n\n",
+        "suffix" : "\nToggle between light, sepia, and dark themes\nZo",
+        "text" : "Highlight any paragraph with one click\nAttach a note to any block"
+      },
+      "author" : "anonymous",
+      "createdAt" : "2026-05-12T20:58:29Z",
+      "id" : "6CE524E4-1EE8-49CC-84D7-EC9811EC1053",
+      "labels" : [
+
+      ],
+      "status" : "open",
+      "thread" : [
+        {
+          "author" : "anonymous",
+          "createdAt" : "2026-05-12T20:58:29Z",
+          "id" : "78BB9F2F-0883-4CB8-998F-1B7135842695",
+          "text" : "Testing21:58"
+        }
+      ]
+    },
+    {
+      "anchor" : {
+        "prefix" : "th one click\nAttach a note to any block\nToggle b",
+        "suffix" : "\n\n\nAnnotations are saved in a hidden .yourfile.m",
+        "text" : "etween light, sepia, and dark themes\nZoom the type with ⌘+ and ⌘-\nPop out an annotations sidebar with ⌘⇧A"
+      },
+      "author" : "anonymous",
+      "createdAt" : "2026-05-12T21:04:06Z",
+      "id" : "46E21EA2-7397-4967-94B4-651C39928E86",
+      "labels" : [
+
+      ],
+      "resolvedAt" : "2026-05-12T21:25:54Z",
+      "resolvedBy" : "anonymous",
+      "status" : "resolved",
+      "thread" : [
+        {
+          "author" : "anonymous",
+          "createdAt" : "2026-05-12T21:04:06Z",
+          "id" : "5F5C5FB9-5E61-4C9A-B676-9A867B4A3D97",
+          "text" : "fffff"
+        }
+      ]
+    },
+    {
+      "anchor" : {
+        "prefix" : "ou can:\n\nHighlight any paragraph with one click\n",
+        "suffix" : "th ⌘⇧A\n\n\nAnnotations are saved in a hidden .your",
+        "text" : "Attach a note to any block\nToggle between light, sepia, and dark themes\nZoom the type with ⌘+ and ⌘-\nPop out an annotations sidebar wi"
+      },
+      "author" : "anonymous",
+      "createdAt" : "2026-05-12T21:25:34Z",
+      "id" : "0DE6ED21-FBD2-41DD-9CD7-F52C8868A2AF",
+      "labels" : [
+
+      ],
+      "resolvedAt" : "2026-05-12T21:25:49Z",
+      "resolvedBy" : "anonymous",
+      "status" : "resolved",
+      "thread" : [
+        {
+          "author" : "anonymous",
+          "createdAt" : "2026-05-12T21:25:34Z",
+          "id" : "1CA116ED-B091-4E7E-99A9-678EFDC39433",
+          "text" : "Hello World"
+        }
+      ]
+    }
+  ],
+  "collaborators" : {
+    "ash" : {
+      "color" : "#4A90D9",
+      "displayName" : "Ash",
+      "email" : "apnaik@amazon.co.uk",
+      "type" : "human"
+    },
+    "claude" : {
+      "color" : "#6B4FBB",
+      "displayName" : "Claude",
+      "mcp" : true,
+      "type" : "agent"
+    },
+    "priya" : {
+      "color" : "#D94A7A",
+      "displayName" : "Priya M",
+      "type" : "human"
+    }
+  },
+  "fileHash" : "sha256:71ea4fb6a65eb4cb9e7faef0972baf085786dda0b04a16c9a9737785dca9b109",
+  "version" : "2.0"
+}

--- a/sample.md.collab.json
+++ b/sample.md.collab.json
@@ -258,6 +258,28 @@
           "text" : "Hello World"
         }
       ]
+    },
+    {
+      "anchor" : {
+        "prefix" : "e to read Markdown.\nWhat it does\nOpen any .md fi",
+        "suffix" : "r style layout. You can:\n\nHighlight any paragrap",
+        "text" : "le and read it in a clean, serif, e-reade"
+      },
+      "author" : "anonymous",
+      "createdAt" : "2026-05-13T05:07:56Z",
+      "id" : "63288F60-C512-45B7-9962-A3B73E25761B",
+      "labels" : [
+
+      ],
+      "status" : "open",
+      "thread" : [
+        {
+          "author" : "anonymous",
+          "createdAt" : "2026-05-13T05:07:56Z",
+          "id" : "B1FD6EE7-5435-4094-9B3C-A108EB751554",
+          "text" : "My name is ash"
+        }
+      ]
     }
   ],
   "collaborators" : {


### PR DESCRIPTION
## Summary

Adds a team collaboration layer to Mindle via a `.collab.json` sidecar. Multiple people (and AI agents) can comment on the same markdown document — threaded replies, assignments, labels, resolve/reopen — all without touching the `.md` file. Syncs via any shared drive (OneDrive, SharePoint, Google Drive). Agents and humans are identical participants. The sidecar's collaborators registry supports `type: "human"` and `type: "agent"` — same schema, same threads, same panel.

## What's included

- **Unified `.collab.json` engine** — `Sources/Collab/` (types, CRUD, merge conflict resolution, identity management)
- **Comment panel (💬 toolbar button)** — threaded cards, reply, resolve, assign, labels, sort, scroll-to-anchor
- **Identity editor** — clickable badge in panel header to set alias + display name
- **Real-time polling** — 1s timer catches external changes (OneDrive sync)
- **Selection-clearing fix** — `reader.js` no longer clears selection on blur, enabling the add-comment flow
- **MCP tool schemas** — `CollabMCPExtensions.swift` defines future tools (`get_comments`, `add_comment`, `propose_change`) ready for wiring into `mindle-mcp`

## Architecture

`document.md` (untouched) + `document.md.collab.json` (collaboration sidecar). The collab panel is a second WKWebView (`CollabPanelView`) in the HSplitView, loading vanilla HTML/CSS/JS. Communication via `webkit.messageHandlers` (JS → Swift) and `evaluateJavaScript` (Swift → JS). Existing `.mindle.json` annotations are completely untouched — both sidecars coexist.

## Files added

- `Sources/Collab/` — CollabTypes, CollabEngine, MergeEngine, IdentityManager, CollabWebBridge, CollabMCPExtensions
- `Sources/mindle/` — CollabPanelView.swift, IdentitySetupView.swift
- `Resources/web/` — collab-panel.html, collab-panel.css, collab-panel.js, collab-bridge.js, collab-highlights.js
- `docs/releases/v2.2.0-collab.md`
- `docs/collab-guide.md`

## Files modified

- `ContentView.swift` — 💬 toolbar button + HSplitView slot
- `DocumentStore.swift` — collab properties, engine, `loadCollabSidecar()`
- `WebReaderView.swift` — `collabNewComment` handler
- `reader.js` — selection-clearing fix (don't post empty selection on blur)
- `build.sh` — added `Sources/Collab/*.swift` + CryptoKit framework

## Compatibility

- All v2.0/v2.1 features unchanged (MCP, diff-on-reload, annotations, themes)
- `.mindle.json` untouched — collab layer is additive
- Schema uses optional fields — older consumers ignore unknown keys

## Known limitations

- ⌘⇧K shortcut unreliable (WebView focus issue) — `+` button works reliably
- No inline highlights in reader pane yet (comments visible in panel only)
- MCP tool schemas defined but not yet wired to `mindle-mcp` binary

## Testing

`./build.sh` then `open build/Mindle.app sample.md` — click 💬 → set identity → select text → + → add comment.

Built and tested on macOS 14+ against v2.1.0-rc3.
