### PR TITLE
feat: team collaboration — extend annotations with status, assign, labels, identity

### DIFF
--- a/Resources/web/reader.css
+++ b/Resources/web/reader.css
@@ -220,6 +220,10 @@ mark.mindle-hl {
   border-radius: 2px;
   cursor: pointer;
 }
+mark.mindle-hl[style*="--collab-color"] {
+  background: color-mix(in srgb, var(--collab-color) 20%, transparent);
+  border-bottom: 2px solid var(--collab-color);
+}
 mark.mindle-hl.has-note {
   background: var(--highlight-note);
 }

--- a/Resources/web/reader.js
+++ b/Resources/web/reader.js
@@ -1176,8 +1176,7 @@
       mark.dataset.annId = ann.id;
       mark.classList.toggle("has-note", !!(ann.note && ann.note.length));
       if (ann.color) {
-        mark.style.backgroundColor = ann.color + "33";
-        mark.style.borderBottom = "2px solid " + ann.color;
+        mark.style.setProperty('--collab-color', ann.color);
       }
       mark.textContent = highlighted;
 

--- a/Resources/web/reader.js
+++ b/Resources/web/reader.js
@@ -1175,6 +1175,10 @@
       mark.className = "mindle-hl";
       mark.dataset.annId = ann.id;
       mark.classList.toggle("has-note", !!(ann.note && ann.note.length));
+      if (ann.color) {
+        mark.style.backgroundColor = ann.color + "33";
+        mark.style.borderBottom = "2px solid " + ann.color;
+      }
       mark.textContent = highlighted;
 
       if (after) {

--- a/Sources/mindle/ContentView.swift
+++ b/Sources/mindle/ContentView.swift
@@ -304,6 +304,7 @@ struct SearchBar: View {
 
 struct AnnotationsSidebar: View {
     @EnvironmentObject var store: DocumentStore
+    @State private var showingIdentityAlert = false
 
     var body: some View {
         let c = store.theme.colors
@@ -315,6 +316,15 @@ struct AnnotationsSidebar: View {
                     .font(.system(size: 13, weight: .semibold, design: .serif))
                     .foregroundStyle(c.text)
                 Spacer()
+
+                Button { store.requestNote() } label: {
+                    Image(systemName: "plus")
+                        .font(.system(size: 12, weight: .medium))
+                        .foregroundStyle(c.accent)
+                }
+                .buttonStyle(.plain)
+                .help("Add comment on selection (⌘⇧N)")
+
                 Text("\(store.annotations.count)")
                     .font(.system(size: 11, design: .monospaced))
                     .foregroundStyle(c.muted)
@@ -326,6 +336,24 @@ struct AnnotationsSidebar: View {
             }
             .padding(.horizontal, 16)
             .padding(.vertical, 12)
+
+            // Identity badge
+            HStack(spacing: 6) {
+                Circle()
+                    .fill(Color(hex: IdentityManager.shared.color))
+                    .frame(width: 7, height: 7)
+                Text(IdentityManager.shared.isConfigured ? IdentityManager.shared.alias : "anonymous")
+                    .font(.system(size: 10))
+                    .foregroundStyle(c.muted)
+                Spacer()
+                Text("click to change")
+                    .font(.system(size: 9))
+                    .foregroundStyle(c.muted.opacity(0.5))
+            }
+            .padding(.horizontal, 16)
+            .padding(.bottom, 6)
+            .contentShape(Rectangle())
+            .onTapGesture { showIdentityAlert() }
 
             Rectangle().fill(c.rule.opacity(0.4)).frame(height: 0.5)
 
@@ -391,6 +419,25 @@ struct AnnotationsSidebar: View {
             }
         }
         .background(c.sidebar)
+    }
+
+    private func showIdentityAlert() {
+        let alert = NSAlert()
+        alert.messageText = "Set Identity"
+        alert.informativeText = "Your alias for annotations (min 2 chars)"
+        alert.addButton(withTitle: "Save")
+        alert.addButton(withTitle: "Cancel")
+        let input = NSTextField(frame: NSRect(x: 0, y: 0, width: 200, height: 24))
+        input.stringValue = IdentityManager.shared.alias
+        input.placeholderString = "e.g. ash"
+        alert.accessoryView = input
+        alert.window.initialFirstResponder = input
+        if alert.runModal() == .alertFirstButtonReturn {
+            let alias = input.stringValue.trimmingCharacters(in: .whitespacesAndNewlines).lowercased()
+            if alias.count >= 2 {
+                IdentityManager.shared.save(alias: alias, displayName: alias, color: IdentityManager.shared.color)
+            }
+        }
     }
 }
 

--- a/Sources/mindle/ContentView.swift
+++ b/Sources/mindle/ContentView.swift
@@ -464,6 +464,76 @@ struct AnnotationCard: View {
                         .frame(width: 2)
                 }
 
+            // Collab: status + assign + labels
+            HStack(spacing: 6) {
+                // Status pill
+                let status = annotation.status ?? .open
+                Text(status.rawValue)
+                    .font(.system(size: 9, weight: .semibold))
+                    .textCase(.uppercase)
+                    .padding(.horizontal, 5)
+                    .padding(.vertical, 1)
+                    .background(status == .resolved ? Color.green.opacity(0.2) : Color.blue.opacity(0.15))
+                    .foregroundStyle(status == .resolved ? .green : c.accent)
+                    .clipShape(Capsule())
+
+                // Resolve/Reopen
+                Button(status == .resolved ? "Reopen" : "Resolve") {
+                    if status == .resolved {
+                        store.reopenAnnotation(id: annotation.id)
+                    } else {
+                        store.resolveAnnotation(id: annotation.id)
+                    }
+                }
+                .font(.system(size: 10))
+                .buttonStyle(.plain)
+                .foregroundStyle(c.muted)
+
+                Spacer()
+
+                // Assign
+                Menu {
+                    ForEach(Array(store.collaborators.keys.sorted()), id: \.self) { alias in
+                        Button(alias) { store.assignAnnotation(id: annotation.id, to: alias) }
+                    }
+                } label: {
+                    Text(annotation.assignee ?? "Assign")
+                        .font(.system(size: 10))
+                        .foregroundStyle(annotation.assignee != nil ? c.accent : c.muted)
+                }
+                .menuStyle(.borderlessButton)
+                .fixedSize()
+
+                // Labels
+                Menu {
+                    ForEach(["question", "blocker", "nit", "todo", "suggestion"], id: \.self) { label in
+                        Button(label) { store.addLabel(to: annotation.id, label: label) }
+                    }
+                } label: {
+                    Image(systemName: "tag")
+                        .font(.system(size: 10))
+                        .foregroundStyle(c.muted)
+                }
+                .menuStyle(.borderlessButton)
+                .fixedSize()
+            }
+            .padding(.top, 2)
+
+            // Labels display
+            if let labels = annotation.labels, !labels.isEmpty {
+                HStack(spacing: 4) {
+                    ForEach(labels, id: \.self) { label in
+                        Text(label)
+                            .font(.system(size: 9))
+                            .padding(.horizontal, 4)
+                            .padding(.vertical, 1)
+                            .background(c.muted.opacity(0.15))
+                            .clipShape(Capsule())
+                            .foregroundStyle(c.muted)
+                    }
+                }
+            }
+
             if isEditing || !annotation.note.isEmpty {
                 TextEditor(text: $noteDraft)
                     .font(.system(size: 12, design: .serif))
@@ -675,7 +745,7 @@ struct AnnotationReplyBox: View {
         store.appendThreadMessage(
             forPath: url.path,
             annotationID: annotationID,
-            author: "user",
+            author: IdentityManager.shared.alias,
             text: trimmed
         )
         draft = ""

--- a/Sources/mindle/ContentView.swift
+++ b/Sources/mindle/ContentView.swift
@@ -437,6 +437,11 @@ struct AnnotationsSidebar: View {
             let alias = input.stringValue.trimmingCharacters(in: .whitespacesAndNewlines).lowercased()
             if alias.count >= 2 {
                 IdentityManager.shared.save(alias: alias, displayName: alias, color: IdentityManager.shared.color)
+            } else {
+                let feedback = NSAlert()
+                feedback.messageText = "Invalid Alias"
+                feedback.informativeText = "Alias must be at least 2 characters."
+                feedback.runModal()
             }
         }
     }
@@ -512,11 +517,11 @@ struct AnnotationCard: View {
                         .frame(width: 2)
                 }
 
-            // Collab: status + assign + labels
-            HStack(spacing: 6) {
-                // Status pill
-                let status = annotation.status ?? .open
-                Text(status.rawValue)
+            // Collab: status + assign + labels (show when collab is active)
+            if annotation.status != nil || annotation.assignee != nil || annotation.labels != nil || !store.collaborators.isEmpty {
+                HStack(spacing: 6) {
+                    let status = annotation.status ?? .open
+                    Text(status.rawValue)
                     .font(.system(size: 9, weight: .semibold))
                     .textCase(.uppercase)
                     .padding(.horizontal, 5)
@@ -581,6 +586,7 @@ struct AnnotationCard: View {
                     }
                 }
             }
+            } // end collab conditional
 
             if isEditing || !annotation.note.isEmpty {
                 TextEditor(text: $noteDraft)

--- a/Sources/mindle/ContentView.swift
+++ b/Sources/mindle/ContentView.swift
@@ -304,6 +304,7 @@ struct SearchBar: View {
 
 struct AnnotationsSidebar: View {
     @EnvironmentObject var store: DocumentStore
+    @ObservedObject private var identity = IdentityManager.shared
     @State private var showingIdentityAlert = false
 
     var body: some View {
@@ -340,9 +341,9 @@ struct AnnotationsSidebar: View {
             // Identity badge
             HStack(spacing: 6) {
                 Circle()
-                    .fill(Color(hex: IdentityManager.shared.color))
+                    .fill(Color(hex: identity.color))
                     .frame(width: 7, height: 7)
-                Text(IdentityManager.shared.isConfigured ? IdentityManager.shared.alias : "anonymous")
+                Text(identity.isConfigured ? identity.alias : "anonymous")
                     .font(.system(size: 10))
                     .foregroundStyle(c.muted)
                 Spacer()

--- a/Sources/mindle/DebugConsoleWindow.swift
+++ b/Sources/mindle/DebugConsoleWindow.swift
@@ -1,0 +1,82 @@
+// DebugConsoleWindow.swift — Floating debug console for annotation/collab events.
+// Toggle with ⌘⇧D. Hidden from menus — developer use only.
+
+import SwiftUI
+import AppKit
+
+final class DebugConsole {
+    static let shared = DebugConsole()
+
+    private var window: NSWindow?
+    private(set) var messages: [String] = []
+    private let maxMessages = 500
+
+    func toggle() {
+        if let w = window, w.isVisible {
+            w.orderOut(nil)
+        } else {
+            show()
+        }
+    }
+
+    func show() {
+        if window == nil {
+            let w = NSWindow(
+                contentRect: NSRect(x: 100, y: 100, width: 520, height: 300),
+                styleMask: [.titled, .closable, .resizable, .miniaturizable],
+                backing: .buffered,
+                defer: false
+            )
+            w.title = "Mindle Debug Console"
+            w.level = .floating
+            w.isReleasedWhenClosed = false
+            w.contentView = NSHostingView(rootView: DebugConsoleView())
+            window = w
+        }
+        window?.makeKeyAndOrderFront(nil)
+    }
+
+    func log(_ message: String) {
+        let timestamp = DateFormatter.localizedString(from: Date(), dateStyle: .none, timeStyle: .medium)
+        let entry = "[\(timestamp)] \(message)"
+        messages.append(entry)
+        if messages.count > maxMessages { messages.removeFirst() }
+        NotificationCenter.default.post(name: .debugConsoleDidLog, object: entry)
+    }
+}
+
+extension Notification.Name {
+    static let debugConsoleDidLog = Notification.Name("debugConsoleDidLog")
+}
+
+struct DebugConsoleView: View {
+    @State private var lines: [String] = DebugConsole.shared.messages
+
+    var body: some View {
+        ScrollViewReader { proxy in
+            ScrollView {
+                LazyVStack(alignment: .leading, spacing: 2) {
+                    ForEach(Array(lines.enumerated()), id: \.offset) { i, line in
+                        Text(line)
+                            .font(.system(size: 11, design: .monospaced))
+                            .foregroundStyle(.green)
+                            .textSelection(.enabled)
+                            .id(i)
+                    }
+                }
+                .padding(8)
+            }
+            .background(Color.black)
+            .onChange(of: lines.count) { _, count in
+                proxy.scrollTo(count - 1, anchor: .bottom)
+            }
+        }
+        .frame(minWidth: 300, minHeight: 150)
+        .onReceive(NotificationCenter.default.publisher(for: .debugConsoleDidLog)) { notif in
+            if let entry = notif.object as? String {
+                lines.append(entry)
+                if lines.count > 500 { lines.removeFirst() }
+            }
+        }
+    }
+}

--- a/Sources/mindle/DocumentStore.swift
+++ b/Sources/mindle/DocumentStore.swift
@@ -589,7 +589,8 @@ final class DocumentStore: ObservableObject {
                 text: selectionText,
                 prefix: selectionPrefix,
                 suffix: selectionSuffix,
-                note: ""
+                note: "",
+                author: IdentityManager.shared.alias
             )
             annotations.append(ann)
             if let url = fileURL {
@@ -618,7 +619,8 @@ final class DocumentStore: ObservableObject {
                 text: selectionText,
                 prefix: selectionPrefix,
                 suffix: selectionSuffix,
-                note: ""
+                note: "",
+                author: IdentityManager.shared.alias
             )
             annotations.append(ann)
             // Defer the `created` event until the user finishes typing

--- a/Sources/mindle/DocumentStore.swift
+++ b/Sources/mindle/DocumentStore.swift
@@ -1076,10 +1076,6 @@ final class DocumentStore: ObservableObject {
     }
 
     /// Ensures the current user is in the sidecar's collaborators registry.
-    private func ensureCollaboratorRegistered() {
-        // This is called on save — we'll register in saveSidecar
-    }
-
     // MARK: - Export
 
     enum ExportFormat { case markdown, json }

--- a/Sources/mindle/DocumentStore.swift
+++ b/Sources/mindle/DocumentStore.swift
@@ -1026,6 +1026,7 @@ final class DocumentStore: ObservableObject {
         annotations[idx].status = .resolved
         annotations[idx].resolvedBy = user ?? IdentityManager.shared.alias
         annotations[idx].resolvedAt = Date()
+        DebugConsole.shared.log("Resolved annotation \(id.uuidString.prefix(8)) by \(annotations[idx].resolvedBy ?? "?")")
         saveSidecar()
     }
 
@@ -1040,6 +1041,7 @@ final class DocumentStore: ObservableObject {
     func assignAnnotation(id: UUID, to assignee: String) {
         guard let idx = annotations.firstIndex(where: { $0.id == id }) else { return }
         annotations[idx].assignee = assignee
+        DebugConsole.shared.log("Assigned \(id.uuidString.prefix(8)) → \(assignee)")
         saveSidecar()
     }
 
@@ -1049,6 +1051,7 @@ final class DocumentStore: ObservableObject {
         if !existing.contains(label) {
             existing.append(label)
             annotations[idx].labels = existing
+            DebugConsole.shared.log("Label +\(label) on \(id.uuidString.prefix(8))")
             saveSidecar()
         }
     }

--- a/Sources/mindle/DocumentStore.swift
+++ b/Sources/mindle/DocumentStore.swift
@@ -538,13 +538,20 @@ final class DocumentStore: ObservableObject {
 
     /// Bump the request signal — WebReaderView observes this, fetches the
     /// live selection from JS, and calls applyHighlight with fresh values.
-    func requestHighlight() { highlightRequestedAt = Date() }
-    func requestNote() { noteRequestedAt = Date() }
+    func requestHighlight() {
+        DebugConsole.shared.log("HIGHLIGHT requested")
+        highlightRequestedAt = Date()
+    }
+    func requestNote() {
+        DebugConsole.shared.log("NOTE requested")
+        noteRequestedAt = Date()
+    }
 
     /// Called by WebReaderView once the JS round-trip returns the live
     /// selection. Overwrites the cached selection with the fresh capture,
     /// then runs the standard highlight/note path.
     func applyHighlight(text: String, prefix: String, suffix: String) {
+        DebugConsole.shared.log("HIGHLIGHT: '\(text.prefix(30))'")
         selectionText = text
         selectionPrefix = prefix
         selectionSuffix = suffix
@@ -552,6 +559,7 @@ final class DocumentStore: ObservableObject {
     }
 
     func applyNote(text: String, prefix: String, suffix: String) {
+        DebugConsole.shared.log("NOTE: '\(text.prefix(30))'")
         selectionText = text
         selectionPrefix = prefix
         selectionSuffix = suffix
@@ -700,6 +708,7 @@ final class DocumentStore: ObservableObject {
         text: String,
         clientID: String? = nil
     ) -> Bool {
+        DebugConsole.shared.log("REPLY: to \(annotationID.uuidString.prefix(8)) by \(author)")
         let message = AnnotationMessage(author: author, text: text)
         if let active = activeTabID,
            let i = tabs.firstIndex(where: { $0.id == active }),
@@ -968,6 +977,7 @@ final class DocumentStore: ObservableObject {
         if let decoded = try? decoder.decode(Sidecar.self, from: data) {
             annotations = decoded.annotations
             collaborators = decoded.collaborators ?? [:]
+            DebugConsole.shared.log("LOAD: \(annotations.count) annotations, \(collaborators.count) collaborators")
             if let t = decoded.theme { theme = t }
             if let s = decoded.fontScale { fontScale = s }
             if let baseline = decoded.lastSyncedText {
@@ -978,6 +988,7 @@ final class DocumentStore: ObservableObject {
 
     func saveSidecar() {
         guard let url = sidecarURL else { return }
+        DebugConsole.shared.log("SAVE: \(annotations.count) annotations")
         let baseline = (lastSyncedText != rawText) ? lastSyncedText : nil
         writeSidecar(to: url, annotations: annotations, lastSynced: baseline)
     }

--- a/Sources/mindle/DocumentStore.swift
+++ b/Sources/mindle/DocumentStore.swift
@@ -36,6 +36,17 @@ struct Annotation: Identifiable, Codable, Equatable {
     /// no replies so existing sidecars round-trip without growth and
     /// the JSON stays minimal for the common case.
     var thread: [AnnotationMessage]?
+
+    // Collab extensions (all optional for backward compat with existing sidecars)
+    var status: AnnotationStatus?    // nil treated as .open
+    var assignee: String?            // collaborator alias
+    var labels: [String]?            // e.g. ["question", "blocker"]
+    var resolvedBy: String?
+    var resolvedAt: Date?
+}
+
+enum AnnotationStatus: String, Codable {
+    case open, resolved, wontfix
 }
 
 struct FileNode: Identifiable, Equatable {
@@ -67,6 +78,8 @@ final class DocumentStore: ObservableObject {
     @Published var fileURL: URL?
     @Published var rawText: String = ""
     @Published var annotations: [Annotation] = []
+    /// Collaborator registry loaded from sidecar — maps alias to display info.
+    @Published var collaborators: [String: SidecarCollaborator] = [:]
     /// Baseline for diff-on-reload. When `lastSyncedText != rawText`, the
     /// reader view shows track-changes between the two. Accepting clears
     /// the diff (lastSyncedText := rawText); rejecting reverts the
@@ -936,6 +949,15 @@ final class DocumentStore: ObservableObject {
         /// it left off. Nil when there's no in-flight diff (the common
         /// case), so existing v1.5 sidecars decode cleanly.
         var lastSyncedText: String?
+        /// Collaborator registry — maps alias to display info. Optional
+        /// so existing sidecars without collab decode cleanly.
+        var collaborators: [String: SidecarCollaborator]?
+    }
+
+    struct SidecarCollaborator: Codable, Equatable {
+        var displayName: String
+        var color: String
+        var type: String?  // "human" or "agent"
     }
 
     private func loadSidecar() {
@@ -945,6 +967,7 @@ final class DocumentStore: ObservableObject {
         decoder.dateDecodingStrategy = .iso8601
         if let decoded = try? decoder.decode(Sidecar.self, from: data) {
             annotations = decoded.annotations
+            collaborators = decoded.collaborators ?? [:]
             if let t = decoded.theme { theme = t }
             if let s = decoded.fontScale { fontScale = s }
             if let baseline = decoded.lastSyncedText {
@@ -978,15 +1001,67 @@ final class DocumentStore: ObservableObject {
         let encoder = JSONEncoder()
         encoder.outputFormatting = [.prettyPrinted, .sortedKeys]
         encoder.dateEncodingStrategy = .iso8601
+        // Register current user in collaborators
+        var collabs = collaborators
+        let im = IdentityManager.shared
+        if im.isConfigured {
+            collabs[im.alias] = im.asSidecarCollaborator()
+        }
         let sidecar = Sidecar(
             annotations: annotations,
             theme: theme,
             fontScale: fontScale,
-            lastSyncedText: lastSynced
+            lastSyncedText: lastSynced,
+            collaborators: collabs.isEmpty ? nil : collabs
         )
         if let data = try? encoder.encode(sidecar) {
             try? data.write(to: url, options: .atomic)
         }
+    }
+
+    // MARK: - Collab Actions
+
+    func resolveAnnotation(id: UUID, by user: String? = nil) {
+        guard let idx = annotations.firstIndex(where: { $0.id == id }) else { return }
+        annotations[idx].status = .resolved
+        annotations[idx].resolvedBy = user ?? IdentityManager.shared.alias
+        annotations[idx].resolvedAt = Date()
+        saveSidecar()
+    }
+
+    func reopenAnnotation(id: UUID) {
+        guard let idx = annotations.firstIndex(where: { $0.id == id }) else { return }
+        annotations[idx].status = .open
+        annotations[idx].resolvedBy = nil
+        annotations[idx].resolvedAt = nil
+        saveSidecar()
+    }
+
+    func assignAnnotation(id: UUID, to assignee: String) {
+        guard let idx = annotations.firstIndex(where: { $0.id == id }) else { return }
+        annotations[idx].assignee = assignee
+        saveSidecar()
+    }
+
+    func addLabel(to id: UUID, label: String) {
+        guard let idx = annotations.firstIndex(where: { $0.id == id }) else { return }
+        var existing = annotations[idx].labels ?? []
+        if !existing.contains(label) {
+            existing.append(label)
+            annotations[idx].labels = existing
+            saveSidecar()
+        }
+    }
+
+    func removeLabel(from id: UUID, label: String) {
+        guard let idx = annotations.firstIndex(where: { $0.id == id }) else { return }
+        annotations[idx].labels?.removeAll { $0 == label }
+        saveSidecar()
+    }
+
+    /// Ensures the current user is in the sidecar's collaborators registry.
+    private func ensureCollaboratorRegistered() {
+        // This is called on save — we'll register in saveSidecar
     }
 
     // MARK: - Export

--- a/Sources/mindle/IdentityManager.swift
+++ b/Sources/mindle/IdentityManager.swift
@@ -1,9 +1,10 @@
 // IdentityManager.swift — Local user identity for team collaboration.
-// Stores alias, display name, and color in UserDefaults.
+// ObservableObject so SwiftUI views refresh when identity changes.
 
 import Foundation
+import SwiftUI
 
-final class IdentityManager {
+final class IdentityManager: ObservableObject {
     static let shared = IdentityManager()
 
     private let defaults = UserDefaults.standard
@@ -18,21 +19,22 @@ final class IdentityManager {
         "#BA68C8", "#4DD0E1", "#F06292", "#AED581"
     ]
 
-    var isConfigured: Bool { defaults.string(forKey: Keys.alias) != nil }
+    @Published var alias: String
+    @Published var displayName: String
+    @Published var color: String
 
-    var alias: String {
-        defaults.string(forKey: Keys.alias) ?? "user"
-    }
+    var isConfigured: Bool { !alias.isEmpty && alias != "user" }
 
-    var displayName: String {
-        defaults.string(forKey: Keys.displayName) ?? alias
-    }
-
-    var color: String {
-        defaults.string(forKey: Keys.color) ?? Self.defaultColors[0]
+    private init() {
+        alias = UserDefaults.standard.string(forKey: Keys.alias) ?? "user"
+        displayName = UserDefaults.standard.string(forKey: Keys.displayName) ?? "user"
+        color = UserDefaults.standard.string(forKey: Keys.color) ?? Self.defaultColors[0]
     }
 
     func save(alias: String, displayName: String, color: String) {
+        self.alias = alias
+        self.displayName = displayName
+        self.color = color
         defaults.set(alias, forKey: Keys.alias)
         defaults.set(displayName, forKey: Keys.displayName)
         defaults.set(color, forKey: Keys.color)

--- a/Sources/mindle/IdentityManager.swift
+++ b/Sources/mindle/IdentityManager.swift
@@ -1,0 +1,45 @@
+// IdentityManager.swift — Local user identity for team collaboration.
+// Stores alias, display name, and color in UserDefaults.
+
+import Foundation
+
+final class IdentityManager {
+    static let shared = IdentityManager()
+
+    private let defaults = UserDefaults.standard
+    private enum Keys {
+        static let alias = "collab.alias"
+        static let displayName = "collab.displayName"
+        static let color = "collab.color"
+    }
+
+    static let defaultColors: [String] = [
+        "#4A90D9", "#E57373", "#81C784", "#FFB74D",
+        "#BA68C8", "#4DD0E1", "#F06292", "#AED581"
+    ]
+
+    var isConfigured: Bool { defaults.string(forKey: Keys.alias) != nil }
+
+    var alias: String {
+        defaults.string(forKey: Keys.alias) ?? "user"
+    }
+
+    var displayName: String {
+        defaults.string(forKey: Keys.displayName) ?? alias
+    }
+
+    var color: String {
+        defaults.string(forKey: Keys.color) ?? Self.defaultColors[0]
+    }
+
+    func save(alias: String, displayName: String, color: String) {
+        defaults.set(alias, forKey: Keys.alias)
+        defaults.set(displayName, forKey: Keys.displayName)
+        defaults.set(color, forKey: Keys.color)
+    }
+
+    /// Returns a SidecarCollaborator for the current user.
+    func asSidecarCollaborator() -> DocumentStore.SidecarCollaborator {
+        DocumentStore.SidecarCollaborator(displayName: displayName, color: color, type: "human")
+    }
+}

--- a/Sources/mindle/MCPServer.swift
+++ b/Sources/mindle/MCPServer.swift
@@ -282,6 +282,37 @@ final class MCPServer {
                 "gap": result.gap
             ]
 
+        case "resolve_annotation":
+            guard let path = request["path"] as? String,
+                  let idStr = request["id"] as? String, let id = UUID(uuidString: idStr) else {
+                return ["ok": false, "error": "missing 'path' or 'id'"]
+            }
+            let author = (request["author"] as? String) ?? "agent"
+            let resolved = await MainActor.run {
+                AppDelegate.shared?.resolveAnnotation(forPath: path, id: id, by: author) ?? false
+            }
+            return resolved ? ["ok": true] : ["ok": false, "error": "annotation not found"]
+
+        case "assign_annotation":
+            guard let path = request["path"] as? String,
+                  let idStr = request["id"] as? String, let id = UUID(uuidString: idStr),
+                  let assignee = request["assignee"] as? String else {
+                return ["ok": false, "error": "missing 'path', 'id', or 'assignee'"]
+            }
+            let assigned = await MainActor.run {
+                AppDelegate.shared?.assignAnnotation(forPath: path, id: id, to: assignee) ?? false
+            }
+            return assigned ? ["ok": true] : ["ok": false, "error": "annotation not found"]
+
+        case "get_collaborators":
+            guard let path = request["path"] as? String else {
+                return ["ok": false, "error": "missing 'path'"]
+            }
+            let result = await MainActor.run {
+                AppDelegate.shared?.collaborators(forPath: path)
+            }
+            return ["ok": true, "collaborators": result ?? [:]]
+
         default:
             return ["ok": false, "error": "unknown op: \(op)"]
         }

--- a/Sources/mindle/MindleApp.swift
+++ b/Sources/mindle/MindleApp.swift
@@ -33,16 +33,6 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
         )
         super.init()
         AppDelegate.shared = self
-
-        // ⌘⇧D — toggle debug console (bypasses WKWebView key capture)
-        NSEvent.addLocalMonitorForEvents(matching: .keyDown) { event in
-            if event.modifierFlags.contains([.command, .shift]),
-               event.charactersIgnoringModifiers == "d" {
-                DebugConsole.shared.toggle()
-                return nil
-            }
-            return event
-        }
     }
 
     func applicationDidFinishLaunching(_ notification: Notification) {

--- a/Sources/mindle/MindleApp.swift
+++ b/Sources/mindle/MindleApp.swift
@@ -33,6 +33,16 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
         )
         super.init()
         AppDelegate.shared = self
+
+        // ⌘⇧D — toggle debug console (bypasses WKWebView key capture)
+        NSEvent.addLocalMonitorForEvents(matching: .keyDown) { event in
+            if event.modifierFlags.contains([.command, .shift]),
+               event.charactersIgnoringModifiers == "d" {
+                DebugConsole.shared.toggle()
+                return nil
+            }
+            return event
+        }
     }
 
     func applicationDidFinishLaunching(_ notification: Notification) {

--- a/Sources/mindle/MindleApp.swift
+++ b/Sources/mindle/MindleApp.swift
@@ -142,6 +142,43 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
         return nil
     }
 
+    func resolveAnnotation(forPath path: String, id: UUID, by author: String) -> Bool {
+        let normalized = URL(fileURLWithPath: path).standardizedFileURL.path
+        for ref in registeredStores {
+            if ref.store?.fileURL?.path == normalized {
+                ref.store?.resolveAnnotation(id: id, by: author)
+                return true
+            }
+        }
+        return false
+    }
+
+    func assignAnnotation(forPath path: String, id: UUID, to assignee: String) -> Bool {
+        let normalized = URL(fileURLWithPath: path).standardizedFileURL.path
+        for ref in registeredStores {
+            if ref.store?.fileURL?.path == normalized {
+                ref.store?.assignAnnotation(id: id, to: assignee)
+                return true
+            }
+        }
+        return false
+    }
+
+    func collaborators(forPath path: String) -> [String: Any]? {
+        let normalized = URL(fileURLWithPath: path).standardizedFileURL.path
+        for ref in registeredStores {
+            if ref.store?.fileURL?.path == normalized {
+                let collabs = ref.store?.collaborators ?? [:]
+                var result: [String: Any] = [:]
+                for (k, v) in collabs {
+                    result[k] = ["displayName": v.displayName, "color": v.color, "type": v.type ?? "human"]
+                }
+                return result
+            }
+        }
+        return nil
+    }
+
     func application(_ sender: NSApplication, open urls: [URL]) {
         if let store = activeStore {
             for url in urls {

--- a/Sources/mindle/MindleApp.swift
+++ b/Sources/mindle/MindleApp.swift
@@ -323,6 +323,13 @@ struct MindleCommands: Commands {
             .keyboardShortcut("n", modifiers: [.command, .shift])
             .disabled(store == nil)
 
+            Button("Add Comment to Selection") {
+                store?.showAnnotations = true
+                store?.requestNote()
+            }
+            .keyboardShortcut("k", modifiers: [.command, .shift])
+            .disabled(store == nil)
+
             Divider()
             Button("Keep All Changes") { store?.acceptAllChanges() }
                 .keyboardShortcut(.return, modifiers: [.command, .option])

--- a/Sources/mindle/MindleApp.swift
+++ b/Sources/mindle/MindleApp.swift
@@ -380,6 +380,9 @@ struct MindleCommands: Commands {
             Button("Toggle Theme") { store?.toggleTheme() }
                 .keyboardShortcut("t", modifiers: [.command, .shift])
                 .disabled(store == nil)
+
+            Button("Debug Console") { DebugConsole.shared.toggle() }
+                .keyboardShortcut("d", modifiers: [.command, .shift])
         }
     }
 }

--- a/Sources/mindle/Theme.swift
+++ b/Sources/mindle/Theme.swift
@@ -66,4 +66,14 @@ extension ReaderTheme {
 
 extension Color {
     var asNSColor: NSColor { NSColor(self) }
+
+    init(hex: String) {
+        let h = hex.trimmingCharacters(in: CharacterSet(charactersIn: "#"))
+        var int: UInt64 = 0
+        Scanner(string: h).scanHexInt64(&int)
+        let r = Double((int >> 16) & 0xFF) / 255.0
+        let g = Double((int >> 8) & 0xFF) / 255.0
+        let b = Double(int & 0xFF) / 255.0
+        self.init(red: r, green: g, blue: b)
+    }
 }

--- a/Sources/mindle/WebReaderView.swift
+++ b/Sources/mindle/WebReaderView.swift
@@ -74,12 +74,14 @@ struct WebReaderView: NSViewRepresentable {
         if store.annotations != coord.lastAnnotations {
             coord.lastAnnotations = store.annotations
             let payload = store.annotations.map { a -> [String: Any] in
-                [
+                let color = store.collaborators[a.author ?? ""]?.color ?? "#FFD700"
+                return [
                     "id": a.id.uuidString,
                     "text": a.text,
                     "prefix": a.prefix,
                     "suffix": a.suffix,
-                    "note": a.note
+                    "note": a.note,
+                    "color": color
                 ]
             }
             if let data = try? JSONSerialization.data(withJSONObject: payload),

--- a/docs/releases/v2.2.0-collab.md
+++ b/docs/releases/v2.2.0-collab.md
@@ -1,0 +1,45 @@
+## v2.2.0-collab — 🤝 Team Collaboration (Integrated)
+
+> 🧪 Feature branch. Built on top of v2.1.0-rc3. Extends the existing annotation system — no parallel sidecar.
+
+Mindle's annotations become a team collaboration surface. Status, assignments, labels, and a collaborator registry are added directly to the existing `.mindle.json` sidecar. Backward compatible — old sidecars decode cleanly.
+
+### What's new
+
+**Annotation status (open/resolved/wontfix).** Each annotation card shows a status pill. Click "Resolve" to mark a thread as addressed, "Reopen" to continue discussion. Status persists in the sidecar.
+
+**Assign to collaborator.** Menu on each annotation card lets you assign it to any collaborator in the registry. Assignee shown on the card.
+
+**Labels.** Tag annotations with presets: question, blocker, nit, todo, suggestion. Labels display as pills on the card.
+
+**Collaborator registry.** The `.mindle.json` sidecar gains an optional `collaborators` map — alias → displayName + color + type. Auto-registers the current user on every save.
+
+**Collaborator-colored highlights.** Each annotation's highlight in the reader uses the author's color from the registry (20% opacity background + solid underline). Falls back to gold if author unknown.
+
+**Identity badge in sidebar.** Shows `● alias` at the top of the annotations sidebar. Click to change your alias via alert dialog. Persisted in UserDefaults.
+
+**+ button in sidebar header.** Quick-add an annotation on the current selection (same as ⌘⇧N).
+
+**⌘⇧K shortcut.** Quick-add an annotation on the current text selection — opens the annotations sidebar and creates a note in one keystroke.
+
+**Debug console (⌘⇧D).** A floating developer window showing live annotation lifecycle events — load/save, highlight, note, reply, resolve, assign, label operations. Green-on-black monospace log, auto-scrolls, hidden by default.
+
+**MCP tools.** `resolve_annotation`, `assign_annotation`, `get_collaborators` added to the MCP server dispatch — agents can participate in the collab workflow.
+
+### Architecture
+
+Extends the existing system — no separate sidecar or panel:
+- `Annotation` struct: +status, +assignee, +labels, +resolvedBy, +resolvedAt (all optional)
+- `Sidecar` struct: +collaborators registry (optional)
+- `AnnotationsSidebar`: resolve/assign/label UI on each card
+- `IdentityManager`: local user identity in UserDefaults
+- `DebugConsole`: floating log window
+
+### Known limitations
+
+- Annotation click → reader scroll only works if the text anchor still matches the DOM (pre-existing Mindle limitation)
+- No filter picker yet (All/Open/Resolved/Mine) — planned for next iteration
+
+---
+
+**Full diff:** `upstream/main..collab/v3-integrated`


### PR DESCRIPTION
## Summary

Reworked per review feedback on #16. Instead of a parallel sidecar + separate WebView panel, this extends Mindle's existing annotation system directly.

### What's added

**To the Annotation struct** (all optional, backward compatible):
- `status` (open/resolved/wontfix)
- `assignee` (collaborator alias)
- `labels` ([String])
- `resolvedBy` / `resolvedAt`

**To the Sidecar** (`.mindle.json`):
- `collaborators` registry — maps alias → displayName, color, type (human/agent)

**To the SwiftUI AnnotationsSidebar:**
- Resolve/reopen button per annotation
- Assign dropdown (from collaborators registry)
- Labels display + add-label menu
- Identity badge (click to set alias/display name)
- `+` button to add annotation on selection

**Infrastructure:**
- `IdentityManager` — local user identity in UserDefaults, real aliases in author field
- Collaborator-colored highlights in reader (per-author underline via `applyAll` pipeline)
- Debug console (⌘⇧D) — floating window logging annotation lifecycle events
- ⌘⇧K shortcut — quick-add annotation on selection
- MCP tools: `resolve_annotation`, `assign_annotation`, `get_collaborators`

### Architecture

Single `.mindle.json` sidecar (extended, not replaced). Single SwiftUI sidebar (extended, not duplicated). Hooks into existing `applyAll()` highlight pipeline. All new fields optional — old sidecars decode cleanly.

### Testing

- Build: `./build.sh` → ✓
- Open sample.md → annotations load with collab fields
- Resolve/assign/label → persisted in sidecar
- Collaborator colors appear in reader highlights
- Debug console (⌘⇧D) shows lifecycle events
- MCP tools respond via Unix socket

### Diff stats

9 commits, ~400 lines added across 8 files. 1 new file (IdentityManager.swift + DebugConsoleWindow.swift).

---

Closes #16 (superseded).