### PR TITLE
Allow selecting text in annotation cards

### DIFF
--- a/Sources/mindle/ContentView.swift
+++ b/Sources/mindle/ContentView.swift
@@ -671,16 +671,18 @@ struct AnnotationCard: View {
                 .help("Delete")
             }
 
-            Text(annotation.text)
-                .font(.system(size: 12, design: .serif))
-                .foregroundStyle(c.text)
-                .lineLimit(4)
-                .padding(.leading, 8)
-                .overlay(alignment: .leading) {
-                    Rectangle()
-                        .fill(dotColor.opacity(0.9))
-                        .frame(width: 2)
-                }
+            SelectableText(
+                text: annotation.text,
+                font: AnnotationMessageRow.bodyFont,
+                textColor: NSColor(c.text),
+                maxLines: 4
+            )
+            .padding(.leading, 8)
+            .overlay(alignment: .leading) {
+                Rectangle()
+                    .fill(dotColor.opacity(0.9))
+                    .frame(width: 2)
+            }
 
             // Hidden for solo-use docs to keep simple highlights clean;
             // surfaces once identity is set (auto-registers in
@@ -1021,10 +1023,11 @@ struct AnnotationMessageRow: View {
                 .fill(stripeColor.opacity(isAgent ? 0.55 : 0.9))
                 .frame(width: isAgent ? 1.5 : 2.5)
             VStack(alignment: .leading, spacing: 3) {
-                Text(message.text)
-                    .font(.system(size: 12, design: .serif))
-                    .foregroundStyle(c.text)
-                    .fixedSize(horizontal: false, vertical: true)
+                SelectableText(
+                    text: message.text,
+                    font: Self.bodyFont,
+                    textColor: NSColor(c.text)
+                )
                 HStack(spacing: 5) {
                     Text(authorLabel)
                         .font(.system(size: 10, weight: .medium))
@@ -1057,6 +1060,15 @@ struct AnnotationMessageRow: View {
         f.dateStyle = .none
         f.timeStyle = .short
         return f
+    }()
+
+    static let bodyFont: NSFont = {
+        let size: CGFloat = 12
+        if let descriptor = NSFont.systemFont(ofSize: size).fontDescriptor.withDesign(.serif),
+           let font = NSFont(descriptor: descriptor, size: size) {
+            return font
+        }
+        return NSFont.systemFont(ofSize: size)
     }()
 }
 

--- a/Sources/mindle/FocusStableTextEditor.swift
+++ b/Sources/mindle/FocusStableTextEditor.swift
@@ -123,6 +123,120 @@ struct FocusStableTextEditor: NSViewRepresentable {
     }
 }
 
+/// Read-only, selectable, word-wrapping text label. Backed by
+/// `NSTextField` so text-selection actually works inside the annotation
+/// sidebar — SwiftUI's `Text(...).textSelection(.enabled)` is unreliable
+/// here because the parent `ForEach(store.annotations)` rebuilds every
+/// card on any store mutation, dropping the in-flight selection.
+/// Same root cause `FocusStableTextEditor` exists for.
+struct SelectableText: NSViewRepresentable {
+    let text: String
+    let font: NSFont
+    let textColor: NSColor
+    /// 0 = unlimited (full wrap). N>0 clamps height to N line-heights and
+    /// truncates with a tail ellipsis.
+    var maxLines: Int = 0
+
+    func makeNSView(context: Context) -> SelectableTextHostView {
+        let host = SelectableTextHostView()
+        host.maxLines = maxLines
+        host.configure(text: text, font: font, textColor: textColor)
+        return host
+    }
+
+    func updateNSView(_ host: SelectableTextHostView, context: Context) {
+        if host.maxLines != maxLines {
+            host.maxLines = maxLines
+        }
+        host.configure(text: text, font: font, textColor: textColor)
+    }
+}
+
+/// AppKit container that owns a non-editable, selectable `NSTextView` and
+/// computes a wrap-aware `intrinsicContentSize` so SwiftUI can lay it out
+/// as a self-sizing block. We can't use a bare `NSTextView` here because
+/// it doesn't expose a wrap-aware intrinsic size — SwiftUI proposes a
+/// width that the text view doesn't read, so it lays out at zero height.
+/// We can't use the `FocusStableTextEditor` `NSScrollView` wrapping
+/// either, because nesting an `NSScrollView` inside SwiftUI's `ScrollView`
+/// fights drag gestures with the outer scroller.
+final class SelectableTextHostView: NSView {
+    private let textView = NSTextView()
+    var maxLines: Int = 0 {
+        didSet { invalidateIntrinsicContentSize() }
+    }
+
+    override init(frame frameRect: NSRect) {
+        super.init(frame: frameRect)
+        setup()
+    }
+
+    required init?(coder: NSCoder) {
+        super.init(coder: coder)
+        setup()
+    }
+
+    private func setup() {
+        textView.isEditable = false
+        textView.isSelectable = true
+        textView.drawsBackground = false
+        textView.backgroundColor = .clear
+        textView.isRichText = false
+        textView.textContainerInset = .zero
+        textView.textContainer?.lineFragmentPadding = 0
+        textView.textContainer?.widthTracksTextView = true
+        textView.isHorizontallyResizable = false
+        textView.isVerticallyResizable = true
+        textView.autoresizingMask = [.width]
+        textView.translatesAutoresizingMaskIntoConstraints = true
+        addSubview(textView)
+    }
+
+    func configure(text: String, font: NSFont, textColor: NSColor) {
+        if textView.string != text {
+            textView.string = text
+        }
+        if textView.font != font {
+            textView.font = font
+        }
+        if textView.textColor != textColor {
+            textView.textColor = textColor
+        }
+        invalidateIntrinsicContentSize()
+    }
+
+    override func layout() {
+        super.layout()
+        textView.frame = bounds
+        textView.textContainer?.size = NSSize(
+            width: bounds.width,
+            height: .greatestFiniteMagnitude
+        )
+        invalidateIntrinsicContentSize()
+    }
+
+    override var intrinsicContentSize: NSSize {
+        guard let lm = textView.layoutManager,
+              let tc = textView.textContainer else {
+            return super.intrinsicContentSize
+        }
+        // Force a layout pass at the current width before we read the
+        // used rect — without this, the height comes back as zero on the
+        // first pass and SwiftUI lays the host at 0pt high.
+        tc.size = NSSize(
+            width: max(bounds.width, 1),
+            height: .greatestFiniteMagnitude
+        )
+        lm.ensureLayout(for: tc)
+        var height = lm.usedRect(for: tc).height
+        if maxLines > 0 {
+            let lineHeight = lm.defaultLineHeight(for: textView.font ?? .systemFont(ofSize: 12))
+            height = min(height, CGFloat(maxLines) * lineHeight)
+        }
+        return NSSize(width: NSView.noIntrinsicMetric, height: ceil(height))
+    }
+}
+
 /// NSTextView subclass that routes bare Return through a commit
 /// closure instead of inserting a newline. Shift+Return inserts a real
 /// newline (the multi-line case).


### PR DESCRIPTION
## Summary

Closes #29 — text inside annotation cards (the highlight body and thread messages) couldn't be selected or copied.

`Text(...).textSelection(.enabled)` doesn't survive the annotation sidebar's per-mutation re-render: every store mutation rebuilds every card via `ForEach(store.annotations)`, and SwiftUI tears down the underlying selectable text view mid-drag. This is the same root cause that drove `FocusStableTextEditor` for the reply box (see `AGENTS.md` → "the reply box is a custom `NSViewRepresentable`…").

The fix replaces those `Text` views with a new `SelectableText` `NSViewRepresentable`, backed by a non-editable `NSTextView` hosted in a plain `NSView`. The `NSView` host owns the text view across SwiftUI rebuilds and computes a wrap-aware `intrinsicContentSize` (forced layout pass at the proposed width, height clamped by an optional `maxLines` for the truncated highlight body).

Two spots updated:
- Thread message text in `AnnotationMessageRow`
- The annotation's highlight body in `AnnotationCard` (preserves the existing 4-line tail truncation)

## Test plan

- [x] Drag-select inside a thread message — selection holds even when the agent posts a sibling reply mid-drag
- [x] ⌘C copies the selected text
- [x] Drag-select inside the highlight body of a card; truncation at 4 lines still works
- [x] Reply box still focuses correctly on click and commits on Return (no regression to `FocusStableTextEditor`)
- [x] Long thread messages wrap correctly at narrow sidebar widths