### PR TITLE
Reader navigation: tab reordering + heading spine

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,6 @@
 build/
+.build/
+.vscode/
 .DS_Store
 *.swp
 *.swo

--- a/Resources/web/reader.js
+++ b/Resources/web/reader.js
@@ -1091,7 +1091,97 @@
       attachDiffHandlers();
       injectDiffBanner();
     }
+
+    // Heading spine: collect h1–h6 positions and publish them. Has to
+    // run after applyAll's mutations settle so offsetTop reflects the
+    // final layout (annotations, math, mermaid all change vertical
+    // positions). markdown-it-anchor is enabled, so each heading already
+    // carries an id we can use for scroll-into-view targeting.
+    publishHeadings();
+    publishScrollState();
   }
+
+  // -------- Heading spine --------
+
+  // Cached so the scroll handler doesn't re-walk the DOM every frame.
+  // Recomputed by publishHeadings() on every render (and on resize, since
+  // wrapping changes heading offsets).
+  let headingCache = [];
+
+  function publishHeadings() {
+    const nodes = doc.querySelectorAll("h1, h2, h3, h4, h5, h6");
+    headingCache = [];
+    const out = [];
+    for (const n of nodes) {
+      // Skip headings that are inside a diff "removed" block — they're
+      // stricken-through history, not navigable structure.
+      if (n.closest('[data-diff="removed"]')) continue;
+      const id = n.id || "";
+      const text = (n.textContent || "").trim();
+      if (!text) continue;
+      const top = Math.max(0, Math.round(n.getBoundingClientRect().top + window.scrollY));
+      const level = parseInt(n.tagName.slice(1), 10) || 1;
+      headingCache.push({ id, top });
+      out.push({ id, text, level, top });
+    }
+    postToSwift("headings", { headings: out });
+  }
+
+  function publishScrollState() {
+    const scrollTop = window.scrollY;
+    const viewportHeight = window.innerHeight;
+    const contentHeight = Math.max(
+      document.documentElement.scrollHeight,
+      document.body.scrollHeight
+    );
+
+    // Active heading: the last one whose top is above the reading "anchor"
+    // line at one third of the viewport. That feels right while scrolling
+    // — a heading lights up when its body has comfortably entered view,
+    // not the moment its first pixel does.
+    const anchorY = scrollTop + viewportHeight * 0.33;
+    let active = -1;
+    for (let i = 0; i < headingCache.length; i++) {
+      if (headingCache[i].top <= anchorY) active = i; else break;
+    }
+    if (active < 0 && headingCache.length > 0) active = 0;
+
+    postToSwift("scrollState", {
+      scrollTop,
+      viewportHeight,
+      contentHeight,
+      activeIndex: active
+    });
+  }
+
+  // Coalesce scroll/resize bursts into a single rAF tick — WKWebView
+  // fires scroll events at full 60Hz and we don't need more than that.
+  let scrollPending = false;
+  function onScrollOrResize() {
+    if (scrollPending) return;
+    scrollPending = true;
+    requestAnimationFrame(() => {
+      scrollPending = false;
+      // Resize can shift heading offsets; cheap to recompute.
+      if (headingCache.length) {
+        for (const h of headingCache) {
+          const el = h.id ? document.getElementById(h.id) : null;
+          if (el) h.top = Math.max(0, Math.round(el.getBoundingClientRect().top + window.scrollY));
+        }
+      }
+      publishScrollState();
+    });
+  }
+  window.addEventListener("scroll", onScrollOrResize, { passive: true });
+  window.addEventListener("resize", onScrollOrResize);
+
+  window.mindleScrollToHeading = function (id) {
+    if (!id) return;
+    const el = document.getElementById(id);
+    if (!el) return;
+    const target = Math.max(0, el.getBoundingClientRect().top + window.scrollY - 24);
+    window.scrollTo({ top: target, behavior: "smooth" });
+  };
 
   // -------- Bionic Text --------
 

--- a/Resources/web/reader.js
+++ b/Resources/web/reader.js
@@ -1108,17 +1108,37 @@
   // wrapping changes heading offsets).
   let headingCache = [];
 
+  function ensureUniqueHeadingID(node, seen) {
+    let id = node.id || "mindle-heading";
+    if (!seen.has(id) && node.id) {
+      seen.add(id);
+      return id;
+    }
+
+    // Keep every spine row scrollable even if the anchor slugger changes
+    // config or a future render path duplicates ids in the DOM.
+    const base = id;
+    let suffix = 2;
+    while (seen.has(id)) {
+      id = `${base}-${suffix++}`;
+    }
+    node.id = id;
+    seen.add(id);
+    return id;
+  }
+
   function publishHeadings() {
     const nodes = doc.querySelectorAll("h1, h2, h3, h4, h5, h6");
     headingCache = [];
     const out = [];
+    const seenIDs = new Set();
     for (const n of nodes) {
       // Skip headings that are inside a diff "removed" block — they're
       // stricken-through history, not navigable structure.
       if (n.closest('[data-diff="removed"]')) continue;
-      const id = n.id || "";
       const text = (n.textContent || "").trim();
       if (!text) continue;
+      const id = ensureUniqueHeadingID(n, seenIDs);
       const top = Math.max(0, Math.round(n.getBoundingClientRect().top + window.scrollY));
       const level = parseInt(n.tagName.slice(1), 10) || 1;
       headingCache.push({ id, top });
@@ -1128,6 +1148,8 @@
   }
 
   function publishScrollState() {
+    if (!headingCache.length) return;
+
     const scrollTop = window.scrollY;
     const viewportHeight = window.innerHeight;
     const contentHeight = Math.max(

--- a/Sources/mindle/ContentView.swift
+++ b/Sources/mindle/ContentView.swift
@@ -1422,6 +1422,8 @@ struct FileTreeRow: View {
 
 struct TabBar: View {
     @EnvironmentObject var store: DocumentStore
+    @State private var isTrailingDropTarget: Bool = false
+    @State private var tabHeight: CGFloat = 0
 
     var body: some View {
         let c = store.theme.colors
@@ -1431,9 +1433,48 @@ struct TabBar: View {
         HStack(spacing: 0) {
             ForEach(store.tabs) { tab in
                 TabBarItem(tab: tab)
+                    .background(
+                        // Publish the tab's rendered height so the trailing
+                        // insertion stripe can match it without being
+                        // height-flexible (which would make HStack
+                        // vertically greedy and balloon the whole bar).
+                        GeometryReader { p in
+                            Color.clear.preference(
+                                key: TabHeightKey.self,
+                                value: p.size.height
+                            )
+                        }
+                    )
+            }
+            // Insertion stripe right after the last tab while a drag is
+            // hovering the trailing area. Height is locked to the tab
+            // row's height — leaving it unbounded would make HStack
+            // (and so VStack) hand the tab bar all available vertical
+            // space. The drop itself is caught by the background layer.
+            if isTrailingDropTarget && tabHeight > 0 {
+                Rectangle()
+                    .fill(c.accent)
+                    .frame(width: 2, height: tabHeight)
             }
             Spacer(minLength: 0)
         }
+        .onPreferenceChange(TabHeightKey.self) { tabHeight = $0 }
+        .background(
+            // Transparent drop catcher sized to the HStack — covers the
+            // empty trailing area so dropping there moves the tab to the
+            // end. Putting this inline as a sibling of the tabs makes
+            // HStack stretch each TabBarItem to its maxWidth (Color is
+            // layout-flexible, Spacer is not), so we hide it behind.
+            Color.clear
+                .contentShape(Rectangle())
+                .onDrop(
+                    of: [.text],
+                    delegate: TrailingTabDropDelegate(
+                        store: store,
+                        isTarget: $isTrailingDropTarget
+                    )
+                )
+        )
         .background(c.surface.opacity(0.5))
         .overlay(alignment: .bottom) {
             Rectangle().fill(c.rule.opacity(0.4)).frame(height: 0.5)
@@ -1441,10 +1482,45 @@ struct TabBar: View {
     }
 }
 
+private struct TabHeightKey: PreferenceKey {
+    static var defaultValue: CGFloat = 0
+    static func reduce(value: inout CGFloat, nextValue: () -> CGFloat) {
+        value = max(value, nextValue())
+    }
+}
+
+/// Drop delegate for the empty trailing area of the tab bar. Sends the
+/// dragged tab to the end of the list. Without this, the rightmost slot
+/// can't be reached because per-tab drops only insert _before_ a target.
+private struct TrailingTabDropDelegate: DropDelegate {
+    let store: DocumentStore
+    @Binding var isTarget: Bool
+
+    func validateDrop(info: DropInfo) -> Bool {
+        info.hasItemsConforming(to: [.text])
+    }
+
+    func dropEntered(info: DropInfo) { isTarget = true }
+    func dropExited(info: DropInfo)  { isTarget = false }
+
+    func performDrop(info: DropInfo) -> Bool {
+        isTarget = false
+        guard let provider = info.itemProviders(for: [.text]).first else { return false }
+        provider.loadObject(ofClass: NSString.self) { item, _ in
+            guard let str = item as? String, let id = UUID(uuidString: str) else { return }
+            Task { @MainActor in
+                store.moveTabToEnd(id: id)
+            }
+        }
+        return true
+    }
+}
+
 struct TabBarItem: View {
     let tab: DocumentTab
     @EnvironmentObject var store: DocumentStore
     @State private var isHovering: Bool = false
+    @State private var isDropTarget: Bool = false
 
     private var remoteTarget: SSHTarget? {
         tab.sourceURL.flatMap(SSHTarget.init(sourceURL:))
@@ -1514,9 +1590,64 @@ struct TabBarItem: View {
             .help("Close tab")
         }
         .background(bg)
+        .overlay(alignment: .leading) {
+            // Insertion indicator while a tab is being dragged onto this
+            // one. Sits on the leading edge — the drop will place the
+            // dragged tab _before_ this one in the list. The trailing-most
+            // slot is reachable via the empty area to the right of the
+            // last tab (see TrailingTabDropDelegate in TabBar).
+            if isDropTarget {
+                Rectangle()
+                    .fill(c.accent)
+                    .frame(width: 2)
+            }
+        }
         .overlay(alignment: .trailing) {
             Rectangle().fill(c.rule.opacity(0.3)).frame(width: 0.5)
         }
         .onHover { isHovering = $0 }
+        .onDrag {
+            // The dragged tab's UUID travels as a plain text string.
+            // SwiftUI's NSItemProvider isn't actor-isolated, so we
+            // build the provider on the calling thread.
+            NSItemProvider(object: tab.id.uuidString as NSString)
+        }
+        .onDrop(
+            of: [.text],
+            delegate: TabDropDelegate(
+                target: tab.id,
+                store: store,
+                isTarget: $isDropTarget
+            )
+        )
+    }
+}
+
+/// Drop delegate for a single tab. Resolves the dragged UUID from the
+/// item provider on drop and asks the store to insert the dragged tab
+/// _before_ this one. The trailing-most slot is handled by a separate
+/// drop zone in `TabBar` (the empty area to the right of the last tab).
+private struct TabDropDelegate: DropDelegate {
+    let target: UUID
+    let store: DocumentStore
+    @Binding var isTarget: Bool
+
+    func validateDrop(info: DropInfo) -> Bool {
+        info.hasItemsConforming(to: [.text])
+    }
+
+    func dropEntered(info: DropInfo) { isTarget = true }
+    func dropExited(info: DropInfo)  { isTarget = false }
+
+    func performDrop(info: DropInfo) -> Bool {
+        isTarget = false
+        guard let provider = info.itemProviders(for: [.text]).first else { return false }
+        provider.loadObject(ofClass: NSString.self) { item, _ in
+            guard let str = item as? String, let id = UUID(uuidString: str) else { return }
+            Task { @MainActor in
+                store.moveTab(id: id, before: target)
+            }
+        }
+        return true
     }
 }

--- a/Sources/mindle/ContentView.swift
+++ b/Sources/mindle/ContentView.swift
@@ -252,6 +252,15 @@ struct ReaderPane: View {
                 } else {
                     WebReaderView()
                         .background(c.background)
+                        .overlay(alignment: .trailing) {
+                            // Floating heading spine — ticks always, labels
+                            // on hover. Self-hides when there are fewer
+                            // than two headings to nav between, so short
+                            // documents don't get a useless rail.
+                            if store.spineHeadings.count >= 2 {
+                                HeadingSpineOverlay()
+                            }
+                        }
                 }
             case .pdf:
                 PDFReaderView()
@@ -283,6 +292,192 @@ struct ReaderPane: View {
                     .transition(.move(edge: .top).combined(with: .opacity))
             }
         }
+    }
+}
+
+/// Floating heading spine on the right edge of the markdown reader.
+/// Collapsed: a thin column of ticks (one per heading) plus an active
+/// dot at the current scroll position. Hovered: expands leftward into
+/// a labeled outline; clicking a row scrolls to that heading.
+///
+/// The vertical mapping uses the heading's pixel offset within the
+/// rendered article (`top / contentHeight`) so the spine reflects the
+/// document's actual structure rather than just an even split — long
+/// chapters get more space, short ones less.
+private struct HeadingSpineOverlay: View {
+    @EnvironmentObject var store: DocumentStore
+    @State private var isHovering: Bool = false
+    @State private var hoveredIndex: Int? = nil
+
+    /// Visible width of the always-on tick column. Also drives the
+    /// overlay's hit area when collapsed — narrow enough that it can't
+    /// accidentally swallow clicks meant for the article underneath.
+    private let collapsedWidth: CGFloat = 22
+    /// Width of the labeled panel that fades in on hover.
+    private let panelWidth: CGFloat = 220
+    /// Vertical inset on top/bottom — keeps ticks off the very edges so
+    /// labels at the extremes don't crash into the rounded corners.
+    private let verticalInset: CGFloat = 28
+
+    var body: some View {
+        // Two stacked layers. Bottom: the spine column (always visible,
+        // narrow, catches hover). Top: the labels panel (only when
+        // hovering). The panel is wider but lives in an .overlay so it
+        // doesn't reserve layout space — the article underneath sees
+        // only the spine's collapsed width when the spine is idle.
+        spineColumn
+            .overlay(alignment: .topTrailing) {
+                if isHovering {
+                    labelsPanel
+                        .transition(.opacity)
+                }
+            }
+            .padding(.trailing, 8)
+    }
+
+    private var spineColumn: some View {
+        let c = store.theme.colors
+        let headings = store.spineHeadings
+        let active = store.spineScroll.activeIndex
+        return GeometryReader { proxy in
+            let track = max(0, proxy.size.height - verticalInset * 2)
+            let positions = trackPositions(in: track, headings: headings)
+            ZStack(alignment: .topTrailing) {
+                ForEach(Array(headings.enumerated()), id: \.element.id) { idx, h in
+                    Rectangle()
+                        .fill(idx == active ? c.accent : c.muted.opacity(0.5))
+                        .frame(width: tickLength(for: h.level), height: idx == active ? 2 : 1)
+                        .offset(x: -6, y: positions[idx] - (idx == active ? 1 : 0.5))
+                        .frame(maxWidth: .infinity, alignment: .trailing)
+                        .allowsHitTesting(false)
+                }
+                if active >= 0, active < positions.count {
+                    Circle()
+                        .fill(c.accent)
+                        .frame(width: 5, height: 5)
+                        .offset(x: -2.5, y: positions[active] - 2.5)
+                        .frame(maxWidth: .infinity, alignment: .trailing)
+                        .allowsHitTesting(false)
+                }
+            }
+            .padding(.vertical, verticalInset)
+        }
+        .frame(width: collapsedWidth)
+        .contentShape(Rectangle())
+        .onHover { hovering in
+            withAnimation(.easeOut(duration: 0.15)) { isHovering = hovering }
+            if !hovering { hoveredIndex = nil }
+        }
+    }
+
+    /// Compact label panel — naturally sized to its content, rendered
+    /// to the LEFT of the spine column when hovering. Uses a VStack of
+    /// Buttons rather than the spine's y-mapped tick layout: that keeps
+    /// the panel small and gives reliable hit-testing (offset tricks +
+    /// contentShape break SwiftUI hit detection on macOS).
+    private var labelsPanel: some View {
+        let c = store.theme.colors
+        let headings = store.spineHeadings
+        let active = store.spineScroll.activeIndex
+        return VStack(alignment: .leading, spacing: 2) {
+            ForEach(Array(headings.enumerated()), id: \.element.id) { idx, h in
+                Button {
+                    store.scrollToHeading(id: h.id)
+                } label: {
+                    HStack(spacing: 8) {
+                        // Active-row dot mirrors the spine's accent dot
+                        // so the connection between the two reads even
+                        // without aligning y-positions exactly.
+                        Circle()
+                            .fill(idx == active ? c.accent : Color.clear)
+                            .frame(width: 5, height: 5)
+                        Text(h.text)
+                            .font(.system(size: fontSize(for: h.level),
+                                          weight: idx == active ? .semibold : .regular))
+                            .foregroundStyle(idx == active ? c.accent : c.text)
+                            .lineLimit(1)
+                            .truncationMode(.tail)
+                            .padding(.leading, indent(for: h.level))
+                        Spacer(minLength: 0)
+                    }
+                    .padding(.vertical, 4)
+                    .padding(.horizontal, 10)
+                    .frame(width: panelWidth - 16, alignment: .leading)
+                    .background(
+                        RoundedRectangle(cornerRadius: 4)
+                            .fill(hoveredIndex == idx ? c.muted.opacity(0.12) : Color.clear)
+                    )
+                    .contentShape(Rectangle())
+                }
+                .buttonStyle(.plain)
+                .onHover { hoveredIndex = $0 ? idx : (hoveredIndex == idx ? nil : hoveredIndex) }
+            }
+        }
+        .padding(8)
+        // fixedSize on vertical lets the VStack hug its content height
+        // instead of stretching to fill the spine's full track. Width
+        // stays fixed at panelWidth so long titles wrap predictably.
+        .fixedSize(horizontal: false, vertical: true)
+        .frame(width: panelWidth, alignment: .leading)
+        .background(
+            RoundedRectangle(cornerRadius: 8, style: .continuous)
+                .fill(c.surface.opacity(0.96))
+                .overlay(
+                    RoundedRectangle(cornerRadius: 8, style: .continuous)
+                        .stroke(c.rule.opacity(0.5), lineWidth: 0.5)
+                )
+                .shadow(color: Color.black.opacity(0.1), radius: 10, x: 0, y: 2)
+        )
+        // Slide left of the spine so the two read as connected. The
+        // outer overlay is `.topTrailing`, so we shift left by the
+        // spine's width plus a small gap.
+        .offset(x: -(collapsedWidth + 4), y: verticalInset - 6)
+        .onHover { hovering in
+            // Keep the panel mounted while the cursor is over it —
+            // without this, hovering off the spine into the panel
+            // would collapse it before any click registered.
+            if hovering { isHovering = true }
+            else {
+                withAnimation(.easeOut(duration: 0.15)) { isHovering = false }
+                hoveredIndex = nil
+            }
+        }
+    }
+
+    private func fontSize(for level: Int) -> CGFloat {
+        switch level {
+        case 1: return 12
+        case 2: return 11.5
+        case 3: return 11
+        default: return 10.5
+        }
+    }
+
+    private func indent(for level: Int) -> CGFloat {
+        CGFloat(min(max(level - 1, 0), 4)) * 10
+    }
+
+    /// Vertical position of each tick inside the track. Maps the
+    /// heading's document offset (`top`) to a fraction of the rendered
+    /// content; falls back to an even split when content height is
+    /// unknown (first frame after load).
+    private func trackPositions(in trackHeight: CGFloat, headings: [SpineHeading]) -> [CGFloat] {
+        guard !headings.isEmpty, trackHeight > 0 else { return [] }
+        let content = store.spineScroll.contentHeight
+        if content <= 0 {
+            let step = headings.count == 1 ? 0 : trackHeight / CGFloat(headings.count - 1)
+            return (0..<headings.count).map { CGFloat($0) * step }
+        }
+        return headings.map { h in
+            let frac = min(max(h.top / content, 0), 1)
+            return frac * trackHeight
+        }
+    }
+
+    private func tickLength(for level: Int) -> CGFloat {
+        // H1 → ~11pt, H6 → ~3pt. Linear interpolation between.
+        let clamped = min(max(level, 1), 6)
+        return 13 - CGFloat(clamped) * 1.6
     }
 }
 

--- a/Sources/mindle/ContentView.swift
+++ b/Sources/mindle/ContentView.swift
@@ -1,5 +1,10 @@
 import SwiftUI
 import AppKit
+import UniformTypeIdentifiers
+
+private extension UTType {
+    static let mindleTab = UTType(exportedAs: "com.fnp.mindle.tab")
+}
 
 struct ContentView: View {
     @EnvironmentObject var store: DocumentStore
@@ -343,7 +348,7 @@ private struct HeadingSpineOverlay: View {
             let track = max(0, proxy.size.height - verticalInset * 2)
             let positions = trackPositions(in: track, headings: headings)
             ZStack(alignment: .topTrailing) {
-                ForEach(Array(headings.enumerated()), id: \.element.id) { idx, h in
+                ForEach(Array(headings.enumerated()), id: \.offset) { idx, h in
                     Rectangle()
                         .fill(idx == active ? c.accent : c.muted.opacity(0.5))
                         .frame(width: tickLength(for: h.level), height: idx == active ? 2 : 1)
@@ -380,7 +385,7 @@ private struct HeadingSpineOverlay: View {
         let headings = store.spineHeadings
         let active = store.spineScroll.activeIndex
         return VStack(alignment: .leading, spacing: 2) {
-            ForEach(Array(headings.enumerated()), id: \.element.id) { idx, h in
+            ForEach(Array(headings.enumerated()), id: \.offset) { idx, h in
                 Button {
                     store.scrollToHeading(id: h.id)
                 } label: {
@@ -428,10 +433,10 @@ private struct HeadingSpineOverlay: View {
                 )
                 .shadow(color: Color.black.opacity(0.1), radius: 10, x: 0, y: 2)
         )
-        // Slide left of the spine so the two read as connected. The
-        // outer overlay is `.topTrailing`, so we shift left by the
-        // spine's width plus a small gap.
-        .offset(x: -(collapsedWidth + 4), y: verticalInset - 6)
+        // Slide left of the spine so the two read as connected. Keeping
+        // the panel flush with the spine avoids a hover dead-zone while
+        // crossing from the tick column into the labels panel.
+        .offset(x: -collapsedWidth, y: verticalInset - 6)
         .onHover { hovering in
             // Keep the panel mounted while the cursor is over it —
             // without this, hovering off the spine into the panel
@@ -1802,13 +1807,21 @@ struct TabBarItem: View {
         }
         .onHover { isHovering = $0 }
         .onDrag {
-            // The dragged tab's UUID travels as a plain text string.
-            // SwiftUI's NSItemProvider isn't actor-isolated, so we
-            // build the provider on the calling thread.
-            NSItemProvider(object: tab.id.uuidString as NSString)
+            // Use a Mindle-specific UTI so only real tab drags can
+            // activate these drop targets. `.ownProcess` still permits
+            // dragging between multiple Mindle windows.
+            let provider = NSItemProvider()
+            provider.registerDataRepresentation(
+                forTypeIdentifier: UTType.mindleTab.identifier,
+                visibility: .ownProcess
+            ) { completion in
+                completion(Data(tab.id.uuidString.utf8), nil)
+                return nil
+            }
+            return provider
         }
         .onDrop(
-            of: [.text],
+            of: [.mindleTab],
             delegate: TabDropDelegate(
                 target: tab.id,
                 store: store,
@@ -1828,7 +1841,7 @@ private struct TabDropDelegate: DropDelegate {
     @Binding var isTarget: Bool
 
     func validateDrop(info: DropInfo) -> Bool {
-        info.hasItemsConforming(to: [.text])
+        info.hasItemsConforming(to: [.mindleTab])
     }
 
     func dropEntered(info: DropInfo) { isTarget = true }
@@ -1836,9 +1849,11 @@ private struct TabDropDelegate: DropDelegate {
 
     func performDrop(info: DropInfo) -> Bool {
         isTarget = false
-        guard let provider = info.itemProviders(for: [.text]).first else { return false }
-        provider.loadObject(ofClass: NSString.self) { item, _ in
-            guard let str = item as? String, let id = UUID(uuidString: str) else { return }
+        guard let provider = info.itemProviders(for: [.mindleTab]).first else { return false }
+        provider.loadDataRepresentation(forTypeIdentifier: UTType.mindleTab.identifier) { data, _ in
+            guard let data,
+                  let str = String(data: data, encoding: .utf8),
+                  let id = UUID(uuidString: str) else { return }
             Task { @MainActor in
                 store.moveTab(id: id, before: target)
             }

--- a/Sources/mindle/DocumentStore.swift
+++ b/Sources/mindle/DocumentStore.swift
@@ -1069,6 +1069,29 @@ final class DocumentStore: ObservableObject {
         loadTabState(target)
     }
 
+    /// Reorder a tab. The dropped tab moves to the position currently
+    /// occupied by `targetID` (inserts before it). The trailing-most
+    /// slot is reached via `moveTabToEnd` — there's no `after` flag here
+    /// because per-tab drop zones only model "insert before".
+    /// No-op if either id is unknown or the move is a no-op.
+    func moveTab(id: UUID, before targetID: UUID) {
+        guard id != targetID,
+              let from = tabs.firstIndex(where: { $0.id == id }),
+              let to = tabs.firstIndex(where: { $0.id == targetID }) else { return }
+        let item = tabs.remove(at: from)
+        let insertIndex = (from < to) ? to - 1 : to
+        tabs.insert(item, at: insertIndex)
+    }
+
+    /// Move a tab to the trailing end of the list. Backs the empty
+    /// drop zone to the right of the last tab in `TabBar`.
+    func moveTabToEnd(id: UUID) {
+        guard let from = tabs.firstIndex(where: { $0.id == id }),
+              from != tabs.count - 1 else { return }
+        let item = tabs.remove(at: from)
+        tabs.append(item)
+    }
+
     func closeTab(id: UUID) {
         guard let i = tabs.firstIndex(where: { $0.id == id }) else { return }
         let isActive = (activeTabID == id)

--- a/Sources/mindle/DocumentStore.swift
+++ b/Sources/mindle/DocumentStore.swift
@@ -177,6 +177,28 @@ struct FileNode: Identifiable, Equatable {
     let children: [FileNode]?   // nil = leaf file; non-nil = directory
 }
 
+/// One heading entry surfaced by the reader for the floating spine.
+/// `top` is in CSS pixels relative to the document — Swift maps it to
+/// a y-fraction by dividing by `SpineScrollState.contentHeight`.
+struct SpineHeading: Equatable, Identifiable {
+    let id: String
+    let text: String
+    let level: Int
+    let top: CGFloat
+}
+
+/// Scroll geometry for the floating heading spine.
+struct SpineScrollState: Equatable {
+    let scrollTop: CGFloat
+    let viewportHeight: CGFloat
+    let contentHeight: CGFloat
+    let activeIndex: Int
+
+    static let empty = SpineScrollState(
+        scrollTop: 0, viewportHeight: 0, contentHeight: 0, activeIndex: -1
+    )
+}
+
 /// One open document inside a window. Active-tab state still lives in
 /// the window-scoped @Published vars (`fileURL`, `rawText`, `annotations`,
 /// `lastSyncedText`) so all existing features keep working untouched;
@@ -314,6 +336,13 @@ final class DocumentStore: ObservableObject {
     @Published private(set) var searchCurrent: Int = 0   // 1-based; 0 = no active match
     @Published var searchNextRequestedAt: Date? = nil
     @Published var searchPrevRequestedAt: Date? = nil
+
+    // Heading spine — populated by the markdown reader. PDF tabs leave
+    // both empty, which hides the overlay.
+    @Published private(set) var spineHeadings: [SpineHeading] = []
+    @Published private(set) var spineScroll: SpineScrollState = .empty
+    @Published var scrollToHeadingRequestedAt: Date? = nil
+    @Published private(set) var scrollToHeadingID: String = ""
 
     // Selection from the web view
     @Published private(set) var selectionText: String = ""
@@ -1129,6 +1158,8 @@ final class DocumentStore: ObservableObject {
             focusedAnnotation = nil
             editingAnnotationID = nil
             updateSelection(text: "", prefix: "", suffix: "")
+            spineHeadings = []
+            spineScroll = .empty
             updateWatcher()
             syncInactiveWatchers()
         }
@@ -1164,6 +1195,11 @@ final class DocumentStore: ObservableObject {
         focusedAnnotation = nil
         editingAnnotationID = nil
         updateSelection(text: "", prefix: "", suffix: "")
+        // Heading spine starts empty — reader.js republishes when the
+        // new tab's markdown finishes rendering. Without this, the
+        // outgoing tab's headings would flash on the incoming one.
+        spineHeadings = []
+        spineScroll = .empty
         // The tab is now visible — clear its unread dot. Keep the prior
         // value so we know to refresh from disk a few lines down.
         let hadUnread: Bool
@@ -1867,6 +1903,32 @@ final class DocumentStore: ObservableObject {
     func updateSearchResult(total: Int, current: Int) {
         searchTotal = total
         searchCurrent = current
+    }
+
+    // MARK: - Heading spine
+
+    /// Headings published by the markdown reader after each render. The
+    /// floating spine overlay reads this to draw ticks; clicking a tick
+    /// asks the reader to scroll to the heading's id.
+    func updateHeadings(_ list: [SpineHeading]) {
+        // Drop publishes that match what we already have — ObservableObject
+        // would otherwise churn the overlay on every render.
+        if list == spineHeadings { return }
+        spineHeadings = list
+    }
+
+    /// Latest scroll fraction + active-heading index from the reader.
+    /// Drives the active dot and the auto-revealed label in the spine.
+    func updateScrollState(_ state: SpineScrollState) {
+        spineScroll = state
+    }
+
+    /// Bumped to ask the WebReader coordinator to scroll the WKWebView
+    /// to the given heading id. Read-once token: `lastScrollToHeadingAt`
+    /// in the coordinator dedupes repeats.
+    func scrollToHeading(id: String) {
+        scrollToHeadingID = id
+        scrollToHeadingRequestedAt = Date()
     }
 
     // MARK: - Persistence

--- a/Sources/mindle/DocumentStore.swift
+++ b/Sources/mindle/DocumentStore.swift
@@ -178,16 +178,23 @@ struct FileNode: Identifiable, Equatable {
 }
 
 /// One heading entry surfaced by the reader for the floating spine.
+/// `id` is the DOM target the reader will scroll to; `reader.js`
+/// normalizes missing/duplicate heading ids before publishing so every
+/// spine row stays addressable even if the slugger configuration shifts.
 /// `top` is in CSS pixels relative to the document — Swift maps it to
 /// a y-fraction by dividing by `SpineScrollState.contentHeight`.
-struct SpineHeading: Equatable, Identifiable {
+struct SpineHeading: Equatable {
     let id: String
     let text: String
     let level: Int
     let top: CGFloat
 }
 
-/// Scroll geometry for the floating heading spine.
+/// Scroll geometry for the floating heading spine. `scrollTop` and
+/// `viewportHeight` are kept even though the current overlay only reads
+/// `contentHeight` + `activeIndex`; the obvious next step is a visible
+/// viewport-range marker, and keeping one payload avoids splitting the
+/// reader's scroll state across parallel bridge messages.
 struct SpineScrollState: Equatable {
     let scrollTop: CGFloat
     let viewportHeight: CGFloat
@@ -197,6 +204,11 @@ struct SpineScrollState: Equatable {
     static let empty = SpineScrollState(
         scrollTop: 0, viewportHeight: 0, contentHeight: 0, activeIndex: -1
     )
+}
+
+struct ScrollToHeadingRequest: Equatable {
+    let id: String
+    let token: Date
 }
 
 /// One open document inside a window. Active-tab state still lives in
@@ -341,8 +353,7 @@ final class DocumentStore: ObservableObject {
     // both empty, which hides the overlay.
     @Published private(set) var spineHeadings: [SpineHeading] = []
     @Published private(set) var spineScroll: SpineScrollState = .empty
-    @Published var scrollToHeadingRequestedAt: Date? = nil
-    @Published private(set) var scrollToHeadingID: String = ""
+    @Published private(set) var scrollToHeadingRequest: ScrollToHeadingRequest? = nil
 
     // Selection from the web view
     @Published private(set) var selectionText: String = ""
@@ -1915,6 +1926,9 @@ final class DocumentStore: ObservableObject {
         // would otherwise churn the overlay on every render.
         if list == spineHeadings { return }
         spineHeadings = list
+        if list.isEmpty, spineScroll != .empty {
+            spineScroll = .empty
+        }
     }
 
     /// Latest scroll fraction + active-heading index from the reader.
@@ -1924,11 +1938,10 @@ final class DocumentStore: ObservableObject {
     }
 
     /// Bumped to ask the WebReader coordinator to scroll the WKWebView
-    /// to the given heading id. Read-once token: `lastScrollToHeadingAt`
-    /// in the coordinator dedupes repeats.
+    /// to the given heading id. Bundling the id with the token avoids a
+    /// transient "new timestamp, old id" window across two publishes.
     func scrollToHeading(id: String) {
-        scrollToHeadingID = id
-        scrollToHeadingRequestedAt = Date()
+        scrollToHeadingRequest = ScrollToHeadingRequest(id: id, token: Date())
     }
 
     // MARK: - Persistence

--- a/Sources/mindle/WebReaderView.swift
+++ b/Sources/mindle/WebReaderView.swift
@@ -16,6 +16,8 @@ struct WebReaderView: NSViewRepresentable {
         userContent.add(context.coordinator, name: "diffSetCurrent")
         userContent.add(context.coordinator, name: "diffAcceptAll")
         userContent.add(context.coordinator, name: "diffRejectAll")
+        userContent.add(context.coordinator, name: "headings")
+        userContent.add(context.coordinator, name: "scrollState")
         config.userContentController = userContent
         config.setURLSchemeHandler(ImageSchemeHandler(), forURLScheme: ImageSchemeHandler.scheme)
         config.defaultWebpagePreferences.allowsContentJavaScript = true
@@ -144,6 +146,11 @@ struct WebReaderView: NSViewRepresentable {
                 self.store.applyNote(text: text, prefix: prefix, suffix: suffix)
             }
         }
+
+        if let t = store.scrollToHeadingRequestedAt, t != coord.lastScrollToHeadingAt {
+            coord.lastScrollToHeadingAt = t
+            web.evaluateJavaScript("window.mindleScrollToHeading(\(jsString(store.scrollToHeadingID)));")
+        }
     }
 
     func makeCoordinator() -> Coordinator { Coordinator(self) }
@@ -170,6 +177,7 @@ struct WebReaderView: NSViewRepresentable {
         var lastPDFExportAt: Date?
         var lastHighlightAt: Date?
         var lastNoteAt: Date?
+        var lastScrollToHeadingAt: Date?
 
         init(_ p: WebReaderView) { parent = p }
 
@@ -360,6 +368,36 @@ struct WebReaderView: NSViewRepresentable {
             case "diffRejectAll":
                 Task { @MainActor in
                     self.parent.store.rejectAllChanges()
+                }
+
+            case "headings":
+                guard let body = message.body as? [String: Any],
+                      let raw = body["headings"] as? [[String: Any]] else { return }
+                let parsed: [SpineHeading] = raw.compactMap { d in
+                    guard let id = d["id"] as? String,
+                          let text = d["text"] as? String,
+                          let level = d["level"] as? Int else { return nil }
+                    let top = (d["top"] as? Double).map { CGFloat($0) } ?? 0
+                    return SpineHeading(id: id, text: text, level: level, top: top)
+                }
+                Task { @MainActor in
+                    self.parent.store.updateHeadings(parsed)
+                }
+
+            case "scrollState":
+                guard let body = message.body as? [String: Any] else { return }
+                let scrollTop = (body["scrollTop"] as? Double).map { CGFloat($0) } ?? 0
+                let viewport = (body["viewportHeight"] as? Double).map { CGFloat($0) } ?? 0
+                let content = (body["contentHeight"] as? Double).map { CGFloat($0) } ?? 0
+                let active = (body["activeIndex"] as? Int) ?? -1
+                let state = SpineScrollState(
+                    scrollTop: scrollTop,
+                    viewportHeight: viewport,
+                    contentHeight: content,
+                    activeIndex: active
+                )
+                Task { @MainActor in
+                    self.parent.store.updateScrollState(state)
                 }
 
             default: break

--- a/Sources/mindle/WebReaderView.swift
+++ b/Sources/mindle/WebReaderView.swift
@@ -147,9 +147,10 @@ struct WebReaderView: NSViewRepresentable {
             }
         }
 
-        if let t = store.scrollToHeadingRequestedAt, t != coord.lastScrollToHeadingAt {
-            coord.lastScrollToHeadingAt = t
-            web.evaluateJavaScript("window.mindleScrollToHeading(\(jsString(store.scrollToHeadingID)));")
+        if let request = store.scrollToHeadingRequest,
+           request.token != coord.lastScrollToHeadingAt {
+            coord.lastScrollToHeadingAt = request.token
+            web.evaluateJavaScript("window.mindleScrollToHeading(\(jsString(request.id)));")
         }
     }
 


### PR DESCRIPTION
## Summary

Two reader-navigation features stacked together:

- **Tab drag-and-drop reorder.** Each tab is draggable; dropping on another tab inserts before it, and a wide trailing drop zone (the empty area to the right of the last tab) sends the dragged tab to the end. Per-tab + trailing zones cover every slot, including the rightmost. In-session only — there's no tab session-restore yet, so order resets on relaunch.
- **Floating heading spine on markdown reader.** Right-edge column of ticks (one per heading, indented by level) tracks scroll position with a small accent dot at the active heading. Hovering the spine reveals a compact panel listing the headings; clicking a row smooth-scrolls to that section. Hidden for PDFs, the editor pane, and docs with fewer than two headings.

Internals: reader.js walks `h1`–`h6` after each render, posts the list + offsets through new `headings` / `scrollState` channels, and accepts a `mindleScrollToHeading(id)` from Swift. The spine maps each heading's pixel offset to a y-fraction so long chapters get more rail than short ones. Spine state clears on tab switch / file close so the outgoing tab's outline doesn't flash on the new one.

## Test plan

- [x] Drag a tab onto another tab → drops before that tab; insertion stripe shows on the leading edge during hover.
- [x] Drag a tab into the empty area right of the last tab → moves to the trailing-most slot; insertion stripe shows after the last tab.
- [x] Open a markdown doc with several `##`/`###` headings → spine ticks visible at the right edge, indented by level.
- [x] Scroll → active dot tracks position; the heading whose body is past the one-third reading line is the active one.
- [x] Hover spine → labeled panel slides in to the left; cursor can move from spine into panel without the panel collapsing.
- [x] Click a row → smooth scroll to that heading; active row highlights in accent color.
- [x] Open a PDF tab → spine hidden.
- [x] Open ⌘E editor → spine hidden.
- [x] Open a markdown doc with 0 or 1 headings → spine hidden.
- [x] Switch tabs → previous tab's headings don't flash on the new tab.

## Note

The tab-reorder commit also drops `.build/` and `.vscode/` into `.gitignore` — small piggyback that landed during an earlier amend. Happy to split out if you'd rather see it on its own.