### PR TITLE
Add Settings window with default font size control

### DIFF
--- a/Sources/mindle/ContentView.swift
+++ b/Sources/mindle/ContentView.swift
@@ -106,13 +106,13 @@ struct ContentView: View {
                 .disabled(!store.hasSelection)
                 .help("Add note to selection (⌘⇧N)")
 
-                Button { store.fontScale = max(0.75, store.fontScale - 0.05) } label: {
+                Button { store.fontScale = FontScaleSteps.previous(before: store.fontScale) } label: {
                     Image(systemName: "textformat.size.smaller")
                         .foregroundStyle(c.text)
                 }
                 .help("Decrease text size (⌘-)")
 
-                Button { store.fontScale = min(1.6, store.fontScale + 0.05) } label: {
+                Button { store.fontScale = FontScaleSteps.next(after: store.fontScale) } label: {
                     Image(systemName: "textformat.size.larger")
                         .foregroundStyle(c.text)
                 }

--- a/Sources/mindle/DocumentStore.swift
+++ b/Sources/mindle/DocumentStore.swift
@@ -252,6 +252,7 @@ final class DocumentStore: ObservableObject {
     /// the fallback for any new doc opened without an override.
     private static let defaultsKeyReadingWidth = "mindle.readingWidth"
     private static let defaultsKeyReadingFont = "mindle.readingFont"
+    private static let defaultsKeyFontScale = "mindle.fontScale"
 
     private static func persistedReadingWidth() -> ReadingWidth {
         if let raw = UserDefaults.standard.string(forKey: defaultsKeyReadingWidth),
@@ -263,6 +264,12 @@ final class DocumentStore: ObservableObject {
         if let raw = UserDefaults.standard.string(forKey: defaultsKeyReadingFont),
            let f = ReadingFont(rawValue: raw) { return f }
         return .serif
+    }
+
+    private static func persistedFontScale() -> Double {
+        let raw = UserDefaults.standard.double(forKey: defaultsKeyFontScale)
+        guard raw > 0 else { return 1.0 }
+        return FontScaleSteps.snapToNearest(raw)
     }
 
     /// Menu-action setter. Updates the visible state *and* persists the
@@ -289,6 +296,7 @@ final class DocumentStore: ObservableObject {
     private func resetReaderPrefsToUserDefaults() {
         readingWidth = Self.persistedReadingWidth()
         readingFont = Self.persistedReadingFont()
+        fontScale = Self.persistedFontScale()
     }
     @Published var showAnnotations: Bool = false
     @Published var showFileBrowser: Bool = false
@@ -1878,7 +1886,7 @@ final class DocumentStore: ObservableObject {
             collaborators = decoded.collaborators ?? [:]
             DebugConsole.shared.log("LOAD: \(annotations.count) annotations, \(collaborators.count) collaborators")
             if let t = decoded.theme { theme = t }
-            if let s = decoded.fontScale { fontScale = s }
+            if let s = decoded.fontScale { fontScale = FontScaleSteps.snapToNearest(s) }
             if let w = decoded.readingWidth { readingWidth = w }
             if let f = decoded.readingFont { readingFont = f }
             if let b = decoded.bionicText { bionicText = b }

--- a/Sources/mindle/FontScaleSteps.swift
+++ b/Sources/mindle/FontScaleSteps.swift
@@ -1,0 +1,37 @@
+/// Single source of truth for valid font-scale values.
+/// All font-size UI (toolbar, menu, Settings stepper) indexes into this table.
+/// Using a fixed table eliminates floating-point drift that accumulates
+/// when repeatedly adding/subtracting 0.05.
+enum FontScaleSteps {
+    /// The 18 discrete font-scale multipliers, 0.75 through 1.60 in steps of 0.05.
+    static let steps: [Double] = stride(from: 0.75, through: 1.60, by: 0.05)
+        .map { ($0 * 100).rounded() / 100 }
+
+    /// Snap an arbitrary Double to the nearest table entry.
+    static func snapToNearest(_ value: Double) -> Double {
+        steps.min(by: { abs($0 - value) < abs($1 - value) }) ?? 1.0
+    }
+
+    /// Index of the nearest step (for stepper arithmetic).
+    static func index(of value: Double) -> Int {
+        let snapped = snapToNearest(value)
+        return steps.firstIndex(of: snapped) ?? steps.firstIndex(of: 1.0)!
+    }
+
+    /// Next step up, clamped at max.
+    static func next(after value: Double) -> Double {
+        let i = index(of: value)
+        return steps[min(i + 1, steps.count - 1)]
+    }
+
+    /// Next step down, clamped at min.
+    static func previous(before value: Double) -> Double {
+        let i = index(of: value)
+        return steps[max(i - 1, 0)]
+    }
+
+    /// Format a step value as a percentage string for display.
+    static func percentageString(for value: Double) -> String {
+        "\(Int((snapToNearest(value) * 100).rounded()))%"
+    }
+}

--- a/Sources/mindle/MindleApp.swift
+++ b/Sources/mindle/MindleApp.swift
@@ -336,6 +336,10 @@ struct MindleApp: App {
         .commands {
             MindleCommands()
         }
+
+        Settings {
+            SettingsView()
+        }
     }
 }
 
@@ -498,14 +502,14 @@ struct MindleCommands: Commands {
 
             Button("Increase Font Size") {
                 guard let store else { return }
-                store.fontScale = min(1.6, store.fontScale + 0.05)
+                store.fontScale = FontScaleSteps.next(after: store.fontScale)
             }
             .keyboardShortcut("+", modifiers: .command)
             .disabled(store == nil)
 
             Button("Decrease Font Size") {
                 guard let store else { return }
-                store.fontScale = max(0.75, store.fontScale - 0.05)
+                store.fontScale = FontScaleSteps.previous(before: store.fontScale)
             }
             .keyboardShortcut("-", modifiers: .command)
             .disabled(store == nil)

--- a/Sources/mindle/SettingsView.swift
+++ b/Sources/mindle/SettingsView.swift
@@ -15,7 +15,10 @@ struct SettingsView: View {
                     }
 
                     Slider(
-                        value: $defaultFontScale,
+                        value: Binding(
+                            get: { defaultFontScale },
+                            set: { defaultFontScale = FontScaleSteps.snapToNearest($0) }
+                        ),
                         in: 0.75...1.60,
                         step: 0.05
                     ) {

--- a/Sources/mindle/SettingsView.swift
+++ b/Sources/mindle/SettingsView.swift
@@ -1,0 +1,39 @@
+import SwiftUI
+
+struct SettingsView: View {
+    @AppStorage("mindle.fontScale") private var defaultFontScale: Double = 1.0
+
+    var body: some View {
+        Form {
+            Section("Reading") {
+                VStack(alignment: .leading, spacing: 12) {
+                    HStack {
+                        Text("Default Font Size")
+                        Spacer()
+                        Text(FontScaleSteps.percentageString(for: defaultFontScale))
+                            .monospacedDigit()
+                    }
+
+                    Slider(
+                        value: $defaultFontScale,
+                        in: 0.75...1.60,
+                        step: 0.05
+                    ) {
+                        Text("Font Size")
+                    } minimumValueLabel: {
+                        Text("A").font(.system(size: 10))
+                    } maximumValueLabel: {
+                        Text("A").font(.system(size: 16))
+                    }
+
+                    Text("The quick brown fox jumps over the lazy dog.")
+                        .font(.system(size: 16 * defaultFontScale, design: .serif))
+                        .foregroundStyle(.secondary)
+                        .frame(maxWidth: .infinity, alignment: .leading)
+                }
+            }
+        }
+        .formStyle(.grouped)
+        .frame(width: 450)
+    }
+}


### PR DESCRIPTION
Introduces a Settings window (⌘,) with a slider for configuring the default font scale new documents open at. Persists via UserDefaults following the existing readingWidth/readingFont pattern.

Key changes:
- FontScaleSteps: canonical step table (0.75–1.60) eliminates float drift
- SettingsView: Form with @AppStorage-backed slider and percentage display
- DocumentStore: persistedFontScale(), resetReaderPrefsToUserDefaults includes fontScale, loadSidecar snaps values to nearest step
- MindleApp/ContentView: ⌘+/⌘- and toolbar buttons use FontScaleSteps

Per-doc sidecar overrides still win. Changing the default does not affect open documents.